### PR TITLE
feat: 노래 데이터 생성 API 구현 및 테스트

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/windry/chordplayer/api/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.windry.chordplayer.api;
+
+import com.windry.chordplayer.dto.ExceptionResponse;
+import com.windry.chordplayer.exception.CustomRuntimeException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomRuntimeException.class)
+    public ResponseEntity<ExceptionResponse> handleRuntimeCustomException(CustomRuntimeException e) {
+        log.error(e.getMessage());
+
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new ExceptionResponse(e.getErrorCode()));
+    }
+
+}

--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -1,18 +1,28 @@
 package com.windry.chordplayer.api;
 
+import com.windry.chordplayer.domain.Tuning;
+import com.windry.chordplayer.dto.CreateSongDto;
+import com.windry.chordplayer.service.SongService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/songs")
 @Slf4j
 public class SongAPI {
 
-//    @PostMapping("")
-//    public ResponseEntity<Void> createSongWithChords(){
-//
-//    }
+    private final SongService songService;
+
+    @PostMapping("")
+    public ResponseEntity<Long> createSongWithChords(
+            @RequestBody CreateSongDto createSongDto
+    ) {
+        Long song = songService.createNewSong(createSongDto);
+        return ResponseEntity.ok().body(song);
+    }
 //
 //    @GetMapping("")
 //    public ResponseEntity<Void> getSongList(){
@@ -20,7 +30,16 @@ public class SongAPI {
 //    }
 //
 //    @GetMapping("/{songId}")
-//    public ResponseEntity<Void> getFilteredSong(){
+//    public ResponseEntity<Void> getFilteredSong(
+//            @PathVariable("songId") Long songId,
+//            @RequestParam(value = "capo", required = false) int capo,
+//            @RequestParam(value = "tuning", required = false)Tuning tuning,
+//            @RequestParam(value = "gender", required = false) Boolean convertGender,
+//            @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
+//            @RequestParam(value = "key",required = false) int key,
+//            @RequestParam("offset") int offset,
+//            @RequestParam("size") int size
+//            ){
 //
 //    }
 //

--- a/src/main/java/com/windry/chordplayer/domain/Chords.java
+++ b/src/main/java/com/windry/chordplayer/domain/Chords.java
@@ -28,8 +28,12 @@ public class Chords extends BaseEntity {
         this.chord = chord;
     }
 
-    public void changeKey(int amount){
-        this.chord = this.chord.replace(this.chord, ChordUtil.notes.get(ChordUtil.notes.indexOf(this.chord) + amount));
+    public void changeKey(int amount) {
+        this.chord = this.chord.replace(this.chord, ChordUtil.sharpNotes.get(ChordUtil.sharpNotes.indexOf(this.chord) + amount));
+    }
 
+    public void changeLyrics(Lyrics lyrics) {
+        this.lyrics = lyrics;
+        lyrics.getChords().add(this);
     }
 }

--- a/src/main/java/com/windry/chordplayer/domain/Gender.java
+++ b/src/main/java/com/windry/chordplayer/domain/Gender.java
@@ -2,5 +2,6 @@ package com.windry.chordplayer.domain;
 
 public enum Gender {
     MALE,
-    FEMALE
+    FEMALE,
+    MIXED
 }

--- a/src/main/java/com/windry/chordplayer/domain/Lyrics.java
+++ b/src/main/java/com/windry/chordplayer/domain/Lyrics.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -22,7 +23,7 @@ public class Lyrics extends BaseEntity {
     private Song song;
 
     @OneToMany(mappedBy = "lyrics", cascade = CascadeType.ALL)
-    private List<Chords> chords;
+    private List<Chords> chords = new ArrayList<>();
 
     private String lyrics;
 
@@ -38,4 +39,10 @@ public class Lyrics extends BaseEntity {
         this.line = line;
         this.tag = tag;
     }
+
+    public void changeSong(Song song){
+        this.song = song;
+        song.getLyricsList().add(this);
+    }
+
 }

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -5,11 +5,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "no_dup_title_with_artist",
+                columnNames = {"title", "artist"}
+        )
+)
 public class Song extends BaseEntity {
 
     @Id
@@ -17,10 +24,10 @@ public class Song extends BaseEntity {
     @Column(name = "SONG_ID")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "title")
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "artist")
     private String artist;
 
     @Column(nullable = false, length = 3)
@@ -34,7 +41,7 @@ public class Song extends BaseEntity {
     private String modulation;
 
     @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
-    private List<Lyrics> lyricsList;
+    private List<Lyrics> lyricsList = new ArrayList<>();
 
     @Builder
     public Song(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation) {
@@ -45,4 +52,15 @@ public class Song extends BaseEntity {
         this.bpm = bpm;
         this.modulation = modulation;
     }
+
+    public void changeRequestFields(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation, List<Lyrics> lyrics) {
+        this.title = title;
+        this.artist = artist;
+        this.originalKey = originalKey;
+        this.gender = gender;
+        this.bpm = bpm;
+        this.modulation = modulation;
+        this.lyricsList = lyrics;
+    }
+
 }

--- a/src/main/java/com/windry/chordplayer/domain/Tag.java
+++ b/src/main/java/com/windry/chordplayer/domain/Tag.java
@@ -4,5 +4,13 @@ public enum Tag {
     INTRO,
     INTERLUDE,
     MODULATION,
-    OUTRO
+    OUTRO;
+
+    public static Tag findTagByString(String str){
+        for(Tag tag: Tag.values()){
+            if(tag.name().equalsIgnoreCase(str))
+                return tag;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/windry/chordplayer/domain/Tuning.java
+++ b/src/main/java/com/windry/chordplayer/domain/Tuning.java
@@ -1,0 +1,24 @@
+package com.windry.chordplayer.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Tuning {
+    STANDARD("E A D G B E"),
+//    DROPPED_D("D A D G B E"),
+//    OPEN_D("D A D F# A D"),
+//    MODAL_D("D A D G A D"),
+//    OPEN_G("D G D G B D"),
+//    OPEN_G_MINOR("D G D G Bb D"),
+//    OPEN_C("C G C G C E"),
+//    MODAL_E("E A D E A E"),
+//    BARITONE_4("B E A D F# B"),
+//    BARITONE_5("A D G C E A"),
+    HALF_STEP("Eb Ab Db Gb Bb Eb"),
+    WHOLE_STEP("D G C F A D");
+
+    private final String sequence;
+
+}

--- a/src/main/java/com/windry/chordplayer/dto/CreateSongDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/CreateSongDto.java
@@ -1,0 +1,33 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.domain.Gender;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class CreateSongDto {
+
+    private String title;
+    private String artist;
+    private String originalKey;
+    private Gender gender;
+    private int bpm;
+    private String modulation;
+    private List<LyricsDto> contents = new ArrayList<>();
+
+    @Builder
+    public CreateSongDto(String title, String artist, String originalKey, Gender gender, int bpm, String modulation, List<LyricsDto> contents) {
+        this.title = title;
+        this.artist = artist;
+        this.originalKey = originalKey;
+        this.gender = gender;
+        this.bpm = bpm;
+        this.modulation = modulation;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/dto/ExceptionResponse.java
+++ b/src/main/java/com/windry/chordplayer/dto/ExceptionResponse.java
@@ -1,0 +1,19 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.exception.ErrorCode;
+import lombok.Data;
+
+@Data
+public class ExceptionResponse {
+    private String errorCode;
+    private String message;
+
+    public ExceptionResponse(ErrorCode errorCode) {
+        this.errorCode = errorCode.getCode();
+    }
+
+    public ExceptionResponse(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/dto/LyricsDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/LyricsDto.java
@@ -1,0 +1,33 @@
+package com.windry.chordplayer.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class LyricsDto {
+
+    private String lyrics;
+    private String tag;
+    private List<String> chords = new ArrayList<>();
+
+    @Builder
+    public LyricsDto(String lyrics, String tag, List<String> chords) {
+        this.lyrics = lyrics;
+        this.tag = tag;
+        this.chords = chords;
+    }
+
+    public void addAllChords(String ...chords){
+        this.chords.addAll(Arrays.asList(chords));
+    }
+
+    public static List<String> getAllChords(String ...chords){
+        return new ArrayList<>(Arrays.asList(chords));
+    }
+}

--- a/src/main/java/com/windry/chordplayer/exception/CustomRuntimeException.java
+++ b/src/main/java/com/windry/chordplayer/exception/CustomRuntimeException.java
@@ -1,0 +1,16 @@
+package com.windry.chordplayer.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomRuntimeException extends RuntimeException{
+    private final HttpStatus status;
+    private final ErrorCode errorCode;
+
+    public CustomRuntimeException(HttpStatus status, ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = status;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/exception/DuplicateTitleAndArtistException.java
+++ b/src/main/java/com/windry/chordplayer/exception/DuplicateTitleAndArtistException.java
@@ -1,0 +1,12 @@
+package com.windry.chordplayer.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class DuplicateTitleAndArtistException extends CustomRuntimeException{
+
+    public DuplicateTitleAndArtistException() {
+        super(HttpStatus.BAD_REQUEST, ErrorCode.DUPLICATE_TITLE_ARTIST);
+    }
+}

--- a/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
+++ b/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.windry.chordplayer.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    DUPLICATE_TITLE_ARTIST("4001", "이미 존재하는 제목과 가수입니다."),
+    INVALID_PARAMETER("4002", "요구되는 입력 값이 유효하지 않거나 존재하지 않습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/windry/chordplayer/exception/InvalidInputException.java
+++ b/src/main/java/com/windry/chordplayer/exception/InvalidInputException.java
@@ -1,0 +1,9 @@
+package com.windry.chordplayer.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidInputException extends CustomRuntimeException {
+    public InvalidInputException() {
+        super(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_PARAMETER);
+    }
+}

--- a/src/main/java/com/windry/chordplayer/repository/ChordsRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/ChordsRepository.java
@@ -1,0 +1,7 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.domain.Chords;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChordsRepository extends JpaRepository<Chords, Long> {
+}

--- a/src/main/java/com/windry/chordplayer/repository/LyricsRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/LyricsRepository.java
@@ -1,0 +1,7 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.domain.Lyrics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LyricsRepository extends JpaRepository<Lyrics, Long> {
+}

--- a/src/main/java/com/windry/chordplayer/repository/SongRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/SongRepository.java
@@ -1,0 +1,14 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.domain.Song;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SongRepository extends JpaRepository<Song, Long> {
+
+    @Query("select s from Song s where replace(s.title, ' ', '') = :title and replace(s.artist, ' ', '') = :artist ")
+    Optional<Song> findSongByTitleAndArtist(@Param("title") String title, @Param("artist") String artist);
+}

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -1,7 +1,74 @@
 package com.windry.chordplayer.service;
 
+import com.windry.chordplayer.domain.Chords;
+import com.windry.chordplayer.domain.Lyrics;
+import com.windry.chordplayer.domain.Song;
+import com.windry.chordplayer.domain.Tag;
+import com.windry.chordplayer.dto.CreateSongDto;
+import com.windry.chordplayer.dto.LyricsDto;
+import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
+import com.windry.chordplayer.exception.InvalidInputException;
+import com.windry.chordplayer.repository.ChordsRepository;
+import com.windry.chordplayer.repository.LyricsRepository;
+import com.windry.chordplayer.repository.SongRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
 
 @Service
+@RequiredArgsConstructor
 public class SongService {
+
+    private final SongRepository songRepository;
+    private final LyricsRepository lyricsRepository;
+    private final ChordsRepository chordsRepository;
+
+    @Transactional
+    public Long createNewSong(CreateSongDto createSongDto) {
+
+        validateDupSongAndArtist(createSongDto.getTitle(), createSongDto.getArtist());
+
+        Song song = Song.builder()
+                .title(createSongDto.getTitle())
+                .artist(createSongDto.getArtist())
+                .gender(createSongDto.getGender())
+                .originalKey(createSongDto.getOriginalKey())
+                .modulation(createSongDto.getModulation())
+                .bpm(createSongDto.getBpm())
+                .build();
+
+        for (int i = 0; i < createSongDto.getContents().size(); i++) {
+            LyricsDto lyricsDto = createSongDto.getContents().get(i);
+            Lyrics lyrics = Lyrics.builder()
+                    .tag(Tag.findTagByString(lyricsDto.getTag()))
+                    .line(i + 1)
+                    .lyrics(lyricsDto.getLyrics())
+                    .build();
+
+            for (String chord : lyricsDto.getChords()) {
+                Chords chords = Chords
+                        .builder()
+                        .chord(chord)
+                        .build();
+                chords.changeLyrics(lyrics);
+                chordsRepository.save(chords);
+            }
+            lyrics.changeSong(song);
+            lyricsRepository.save(lyrics);
+        }
+        return songRepository.save(song).getId();
+    }
+
+    public void validateDupSongAndArtist(String title, String artist) {
+        if (title == null || artist == null)
+            throw new InvalidInputException();
+
+        // 공백 무시하고 검색 가능
+        Optional<Song> song = songRepository.findSongByTitleAndArtist(title.trim(), artist.trim());
+        if (song.isPresent())
+            throw new DuplicateTitleAndArtistException();
+    }
 }

--- a/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
+++ b/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
@@ -1,0 +1,131 @@
+package com.windry.chordplayer.service;
+
+import com.windry.chordplayer.domain.Gender;
+import com.windry.chordplayer.domain.Song;
+import com.windry.chordplayer.dto.CreateSongDto;
+import com.windry.chordplayer.dto.LyricsDto;
+import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
+import com.windry.chordplayer.repository.ChordsRepository;
+import com.windry.chordplayer.repository.LyricsRepository;
+import com.windry.chordplayer.repository.SongRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@SpringBootTest
+@Transactional
+class SongServiceTest {
+
+    @Autowired
+    private SongRepository songRepository;
+    @Autowired
+    private LyricsRepository lyricsRepository;
+    @Autowired
+    private ChordsRepository chordsRepository;
+    @Autowired
+    private SongService songService;
+
+
+    @DisplayName("노래 데이터를 생성할 때, 중복되는 제목과 가수가 있을 경우 예외를 발생한다.")
+    @Test
+    void duplicateSongTitleAndArtistException() {
+        // given
+        Song song = new Song();
+        CreateSongDto songDto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("이적")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .build();
+
+        song.changeRequestFields(
+                songDto.getTitle(),
+                songDto.getArtist(),
+                songDto.getOriginalKey(),
+                songDto.getGender(),
+                songDto.getBpm(),
+                songDto.getModulation(),
+                null);
+
+        Song differentArtistSong = new Song();
+        differentArtistSong.changeRequestFields(
+                songDto.getTitle(),
+                "허각",
+                songDto.getOriginalKey(),
+                songDto.getGender(),
+                songDto.getBpm(),
+                songDto.getModulation(),
+                null
+        );
+        // when
+        songRepository.save(song);
+        songRepository.save(differentArtistSong);
+
+        // then
+        Assertions.assertEquals("허각", songRepository.findById(2L).get().getArtist());
+        Assertions.assertThrows(DuplicateTitleAndArtistException.class, () -> songService.validateDupSongAndArtist("하늘을달리다", "이적"));
+    }
+
+    @DisplayName("4박자 마디의 가사와 코드가 포함된 새로운 노래 데이터를 생성한다.")
+    @Test
+    void createNewSong() {
+        // given
+        Song song = new Song();
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
+        );
+
+        CreateSongDto songDto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("이적")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .build();
+
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        songDto.setContents(lyricsDtoList);
+
+        // when
+        Long newSong = songService.createNewSong(songDto);
+
+        // then
+        org.assertj.core.api.Assertions.assertThat(song)
+                .usingRecursiveComparison()
+                .ignoringFields("createdDate", "modifiedDate", "id", "lyricsList")
+                .isEqualTo(songRepository.findById(newSong).get());
+    }
+}


### PR DESCRIPTION
- 엔티티의 연관관계 편의 메소드를 만들 때, OneToMany 입장에서 One에 해당하는 Lyrics 엔티티가 song의 `List<Lyrics>`에 접근하는데 리스트 자체가 초기화가 되어있지 않아서 NPE가 발생했었다. 그러니 엔티티에서 List 타입은 항상 초기화 시켜놓자.
- Java의 가변인자 문법을 처음봤었다... 연관관계가 있을 때, 다량의 데이터를 넣을 때 유용한거같다.
- Song 레포지토리에서 제목 & 가수에 대한 중복 검증을 위해 DB에서 해당 데이터가 있는지 없는지 서칭을 할 때, 공백을 모두 무시하고 싶었기에 단순 메소드 이름으로 구현하기 어려워 JPQL을 작성했다.
  - `@Query` 어노테이션을 사용.
  - 공백을 지우기 위해 `replace(field, target, replace)` 함수를 사용했다. 
  - 제목과 가수에 대한 Input을 받기 위해 파라미터를 받아놨는데 `@Query` 어노테이션으로 JPQL문을 작성하게 되면 안의 인자 값을 지정해줘야하는 문제가 있었어서 각 파라미터에 `@Param` 어노테이션을 추가해줬다. 
- 테스트할 때, 테스트 객체와 실제 서비스에 의해 생성된 객체를 비교하려는데, 이는 주소 값으로 비교했기 때문에 테스트에 실패했었다.
  - 그래서 엔티티에 `equals()`와 `hashCode()`를 구현해줬어야하는데 뭔가 굳이라는 생각이 들어서 다른 방법을 찾아보다가 Assertj의 `usingRecursiveComparison()` 메소드가 그 역할을 해주어서 사용했다. 추가적으로 비교할 때 제외하고 싶은 필드들도 지정할 수 있어서 유용했다. 