### PR TITLE
refactor: 엔티티 일부 수정 및 노래 생성 서비스 로직 수정

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/windry/chordplayer/api/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(e.getStatus())
-                .body(new ExceptionResponse(e.getErrorCode()));
+                .body(new ExceptionResponse(e.getErrorCode().getCode(), e.getMessage()));
     }
 
 }

--- a/src/main/java/com/windry/chordplayer/domain/Lyrics.java
+++ b/src/main/java/com/windry/chordplayer/domain/Lyrics.java
@@ -45,4 +45,9 @@ public class Lyrics extends BaseEntity {
         song.getLyricsList().add(this);
     }
 
+    public void addChords(Chords chord){
+        chords.add(chord);
+        chord.changeLyrics(this);
+    }
+
 }

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +41,9 @@ public class Song extends BaseEntity {
 
     private String modulation;
 
+    @ColumnDefault("0")
+    private int viewCount;
+
     @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
     private List<Lyrics> lyricsList = new ArrayList<>();
 
@@ -63,4 +67,8 @@ public class Song extends BaseEntity {
         this.lyricsList = lyrics;
     }
 
+    public void addLyrics(Lyrics lyrics){
+        lyricsList.add(lyrics);
+        lyrics.changeSong(this);
+    }
 }


### PR DESCRIPTION
- 노래 생성 시, 코드 데이터 save() 후, 코드의 Lyrics를 지정하는 것이 아닌, Lyrics에 코드를 추가하고, Chords에 Lyrics를 설정하는 방식으로 변경. 이로써 Cascade 효과 발동으로 Lyrics 저장 시, 연관관계로 인해 Chords도 한번에 저장. (Song <-> Lyrics 연관관계도 마찬가지로 적용)
  - 이로 인해 테스트 케이스로 예전 로직에서는 INSERT 쿼리 7번, UPDATE 쿼리 6번이 나갔다면
  - 로직 변경 후, INSERT 쿼리 7번만 나가게 됨.
- 중복되는 제목 및 가수 검증을 하는데 있어서, 공백을 모두 무시하고 검색하기 때문에 공백을 제거하고 parameter에 넘겨줬어야 했는데, `trim()` 메소드가 모든 공백 제거하는 것으로 착각했었다. 그래서 `replace()` 메소드로 변경해주었다.
- 글로벌 Exception Handler의 응답으로 에러 코드만 오니 알아보기 힘들어, 에러 메세지까지 함께 응답으로 주도록 수정했다.
- Song 엔티티에 viewCount 필드 추가하고 `@ColumnDefault()` 라는 어노테이션을 통해 기본 값도 함께 부여했다. 