### PR TITLE
feat: 코드 추출 및 키 변경 기능 유틸 함수 구현 및 테스트 완료

### DIFF
--- a/src/main/java/com/windry/chordplayer/dto/ChordUtil.java
+++ b/src/main/java/com/windry/chordplayer/dto/ChordUtil.java
@@ -1,11 +1,80 @@
 package com.windry.chordplayer.dto;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ChordUtil {
+    private static final Map<String, Integer> chordOrdersAtoI = init();
+    private static final List<String[]> chordOrdersItoA = init2();
+    private static final Pattern CHORD_PATTERN = Pattern.compile("^([A-G][#b]?).*"); // A ~ G , # 또는 b가 0 또는 1 회 등장, 그 뒤에 임의의 문자
 
-    private static final String[] n = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-    public static final List<String> notes = Arrays.stream(n).toList();
+    private static Map<String, Integer> init() {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("C", 0);
+        map.put("Db", 1);
+        map.put("C#", 1);
+        map.put("D", 2);
+        map.put("D#", 3);
+        map.put("Eb", 3);
+        map.put("E", 4);
+        map.put("F", 5);
+        map.put("F#", 6);
+        map.put("Gb", 6);
+        map.put("G", 7);
+        map.put("G#", 8);
+        map.put("Ab", 8);
+        map.put("A", 9);
+        map.put("A#", 10);
+        map.put("Bb", 10);
+        map.put("B", 11);
+        return map;
+    }
+
+    private static List<String[]> init2() {
+        List<String[]> list = new ArrayList<>();
+        list.add(new String[]{"C"});
+        list.add(new String[]{"C#", "Db"});
+        list.add(new String[]{"D"});
+        list.add(new String[]{"D#", "Eb"});
+        list.add(new String[]{"E"});
+        list.add(new String[]{"F"});
+        list.add(new String[]{"F#", "Gb"});
+        list.add(new String[]{"G"});
+        list.add(new String[]{"G#", "Ab"});
+        list.add(new String[]{"A"});
+        list.add(new String[]{"A#", "Bb"});
+        list.add(new String[]{"B"});
+        return list;
+    }
+
+    public static String changeKey(String originChord, int amount) {
+        if (originChord.contains("/")) {
+            String[] split = originChord.split("/");
+
+            String baseChord = extractBaseChord(split[0]);
+            String slashRoot = split[1];
+
+            int order1 = chordOrdersAtoI.get(baseChord);
+            int order2 = chordOrdersAtoI.get(slashRoot);
+
+            String s = chordOrdersItoA.get((order1 + amount) % 12)[0];
+            String s1 = chordOrdersItoA.get((order2 + amount) % 12)[0];
+            return split[0].replace(baseChord, s) + "/" + s1;
+        }
+
+        String base = extractBaseChord(originChord);
+        int order = chordOrdersAtoI.get(base);
+
+        return originChord.replace(base, chordOrdersItoA.get((order + amount) % 12)[0]);
+    }
+
+    public static String extractBaseChord(String chord) {
+        Matcher matcher = CHORD_PATTERN.matcher(chord);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
 
 }

--- a/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
+++ b/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
@@ -1,0 +1,29 @@
+package com.windry.chordplayer.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChordUtilTest {
+
+    @Test
+    void changeKey() {
+        String s1 = ChordUtil.changeKey("Gbm/Bb", 3); // Gb - G - G# - A
+        String s2 = ChordUtil.changeKey("F#sus4/A#", 3);
+        String s3 = ChordUtil.changeKey("G/B", -2);
+        String s4 = ChordUtil.changeKey("FM7", 2);
+        String s5 = ChordUtil.changeKey("Bb9sus4", 3);
+        String s6 = ChordUtil.changeKey("B7/A", -4);
+        String s7 = ChordUtil.changeKey("AbM7", 1);
+        String s8 = ChordUtil.changeKey("Fmaj7", 3);
+
+        assertEquals("Am/C#", s1);
+        assertEquals("Asus4/C#", s2);
+        assertEquals("F/A", s3);
+        assertEquals("GM7", s4);
+        assertEquals("C#9sus4", s5);
+        assertEquals("G7/F", s6);
+        assertEquals("AM7", s7);
+        assertEquals("G#maj7", s8);
+    }
+}


### PR DESCRIPTION
- Map과 List를 사용하여 기본 음계의 시퀀스 정의
- 숫자 또는 문자열로 서로 변환이 가능하도록 정의, 각 시퀀스에는 순서 값을 정의하여 F#과 Gb이 동일 선상에 위치하도록 정의
- 코드가 주어졌을 때 이 코드의 원본 코드가 무엇인지 추출하는 함수를 정규표현식을 사용하여 구현
- 정규표현식에서 추출한 원본코드에 대해 키를 변경해주고 최종 변경된 코드를 반환해주는 키 변경 유틸 함수 구현 완료
- 실제 여러개의 코드를 가지고 키 변경 테스트 완료