### PR TITLE
fix: 음계 시퀀스가 음수가 되는 현상 수정

### DIFF
--- a/src/main/java/com/windry/chordplayer/dto/ChordUtil.java
+++ b/src/main/java/com/windry/chordplayer/dto/ChordUtil.java
@@ -1,5 +1,7 @@
 package com.windry.chordplayer.dto;
 
+import com.windry.chordplayer.exception.NotFoundChordException;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,33 +50,68 @@ public class ChordUtil {
         return list;
     }
 
+    /**
+     * 주어진 변형 코드와 변경할 값만큼 키를 변경해주는 기능
+     *
+     * @param originChord 주어진 변형 코드
+     * @param amount      변경하고싶은 키 값 (음수, 양수 모두 가능)
+     * @return 최종 키가 변경된 코드 문자열
+     */
     public static String changeKey(String originChord, int amount) {
+        if (amount == 0)
+            return originChord;
+
+        if (originChord == null)
+            throw new NotFoundChordException();
+
+        // 분수 코드 존재할 경우
         if (originChord.contains("/")) {
             String[] split = originChord.split("/");
 
             String baseChord = extractBaseChord(split[0]);
             String slashRoot = split[1];
 
-            int order1 = chordOrdersAtoI.get(baseChord);
-            int order2 = chordOrdersAtoI.get(slashRoot);
+            int baseOrder = chordOrdersAtoI.get(baseChord);
+            int slashOrder = chordOrdersAtoI.get(slashRoot);
 
-            String s = chordOrdersItoA.get((order1 + amount) % 12)[0];
-            String s1 = chordOrdersItoA.get((order2 + amount) % 12)[0];
-            return split[0].replace(baseChord, s) + "/" + s1;
+            String changedBase = chordOrdersItoA.get(getCircularOrder(baseOrder, amount))[0];
+            String changedSlash = chordOrdersItoA.get(getCircularOrder(slashOrder, amount))[0];
+            return split[0].replace(baseChord, changedBase) + "/" + changedSlash;
         }
 
         String base = extractBaseChord(originChord);
         int order = chordOrdersAtoI.get(base);
 
-        return originChord.replace(base, chordOrdersItoA.get((order + amount) % 12)[0]);
+        return originChord.replace(base, chordOrdersItoA.get(getCircularOrder(order, amount))[0]);
     }
 
+    /**
+     * 주어진 코드를 정규표현식에 따라 매칭하고 원본 코드를 추출
+     *
+     * @param chord 주어진 변형 코드
+     * @return 변형 코드에서 추출한 원본 코드
+     * @throws NotFoundChordException: 주어진 코드에서 원본 코드를 추출할 수 없을 때 발생
+     */
     public static String extractBaseChord(String chord) {
         Matcher matcher = CHORD_PATTERN.matcher(chord);
         if (matcher.matches()) {
             return matcher.group(1);
         }
-        return null;
+        throw new NotFoundChordException();
     }
 
+    /**
+     * 주어진 음계 시퀀스의 순서를 키 변경에 따라 순환에 의한 순서를 반환해주는 기능
+     *
+     * @param order  주어진 순서
+     * @param amount 바꾸고자 하는 키 값
+     * @return 순환에 따라 변경된 순서 값 반환
+     */
+    private static int getCircularOrder(int order, int amount) {
+        if (order + amount < 0) {
+            return chordOrdersItoA.size() + (order + amount);
+        } else {
+            return (order + amount) % chordOrdersItoA.size();
+        }
+    }
 }

--- a/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
+++ b/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     DUPLICATE_TITLE_ARTIST("4001", "이미 존재하는 제목과 가수입니다."),
-    INVALID_PARAMETER("4002", "요구되는 입력 값이 유효하지 않거나 존재하지 않습니다.");
+    INVALID_PARAMETER("4002", "요구되는 입력 값이 유효하지 않거나 존재하지 않습니다."),
+    INVALID_CHORD_MATCH("4003", "존재하지 않는 코드 형태입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/windry/chordplayer/exception/NotFoundChordException.java
+++ b/src/main/java/com/windry/chordplayer/exception/NotFoundChordException.java
@@ -1,0 +1,9 @@
+package com.windry.chordplayer.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundChordException extends CustomRuntimeException {
+    public NotFoundChordException() {
+        super(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_CHORD_MATCH);
+    }
+}

--- a/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
+++ b/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
@@ -16,6 +16,7 @@ class ChordUtilTest {
         String s6 = ChordUtil.changeKey("B7/A", -4);
         String s7 = ChordUtil.changeKey("AbM7", 1);
         String s8 = ChordUtil.changeKey("Fmaj7", 3);
+        String s9 = ChordUtil.changeKey("C#m7", -4);
 
         assertEquals("Am/C#", s1);
         assertEquals("Asus4/C#", s2);
@@ -25,5 +26,6 @@ class ChordUtilTest {
         assertEquals("G7/F", s6);
         assertEquals("AM7", s7);
         assertEquals("G#maj7", s8);
+        assertEquals("Am7", s9);
     }
 }


### PR DESCRIPTION
- 음계 순서 값이 낮고 키 변경 값이 높을 때 음계 시퀀스의 인덱스 값이 음수가 되어 index bound exception이 발생함
- 그래서 순서 값이 순환하도록 하는 유틸 메소드 추가
- 키 변경할 때 주어진 코드 값에 문제가 있거나 null일 때 exception 처리 추가
- 마찬가지로 첫번째 현상에 대한 테스트 케이스 추가 및 테스트 완료