### PR TITLE
feat: 노래 목록 조회 API 구현 및 장르 필드 추가

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -1,12 +1,20 @@
 package com.windry.chordplayer.api;
 
+import com.windry.chordplayer.domain.Gender;
+import com.windry.chordplayer.domain.SearchCriteria;
+import com.windry.chordplayer.domain.SortStrategy;
 import com.windry.chordplayer.domain.Tuning;
 import com.windry.chordplayer.dto.CreateSongDto;
+import com.windry.chordplayer.dto.FiltersOfSongList;
+import com.windry.chordplayer.dto.SongListItemDto;
+import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.service.SongService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,11 +31,35 @@ public class SongAPI {
         Long song = songService.createNewSong(createSongDto);
         return ResponseEntity.ok().body(song);
     }
-//
-//    @GetMapping("")
-//    public ResponseEntity<Void> getSongList(){
-//
-//    }
+
+    @GetMapping("")
+    public ResponseEntity<List<SongListItemDto>> getSongList(
+            @RequestParam("page") Integer page,
+            @RequestParam("size") Integer size,
+            @RequestParam(value = "searchCriteria", required = false) SearchCriteria searchCriteria,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "gender", required = false) Gender gender,
+            @RequestParam(value = "key", required = false) String key,
+            @RequestParam(value = "genre", required = false) String genre,
+            @RequestParam(value = "sort", required = false) SortStrategy sortStrategy
+    ) {
+
+        if(page == null || size == null)
+            throw new InvalidInputException();
+
+        FiltersOfSongList filters = FiltersOfSongList.builder()
+                .searchCriteria(searchCriteria)
+                .searchKeyword(keyword)
+                .gender(gender)
+                .sortStrategy(sortStrategy)
+                .searchGenre(genre)
+                .searchKey(key)
+                .build();
+
+        List<SongListItemDto> allSongs = songService.getAllSongs(filters, page, size);
+
+        return ResponseEntity.ok().body(allSongs);
+    }
 //
 //    @GetMapping("/{songId}")
 //    public ResponseEntity<Void> getFilteredSong(

--- a/src/main/java/com/windry/chordplayer/domain/Chords.java
+++ b/src/main/java/com/windry/chordplayer/domain/Chords.java
@@ -1,6 +1,5 @@
 package com.windry.chordplayer.domain;
 
-import com.windry.chordplayer.dto.ChordUtil;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,10 +25,6 @@ public class Chords extends BaseEntity {
     @Builder
     public Chords(String chord) {
         this.chord = chord;
-    }
-
-    public void changeKey(int amount) {
-        this.chord = this.chord.replace(this.chord, ChordUtil.sharpNotes.get(ChordUtil.sharpNotes.indexOf(this.chord) + amount));
     }
 
     public void changeLyrics(Lyrics lyrics) {

--- a/src/main/java/com/windry/chordplayer/domain/Genre.java
+++ b/src/main/java/com/windry/chordplayer/domain/Genre.java
@@ -1,0 +1,25 @@
+package com.windry.chordplayer.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "GENRE_ID")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Builder
+    public Genre(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/domain/Lyrics.java
+++ b/src/main/java/com/windry/chordplayer/domain/Lyrics.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +25,7 @@ public class Lyrics extends BaseEntity {
     private Song song;
 
     @OneToMany(mappedBy = "lyrics", cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Chords> chords = new ArrayList<>();
 
     private String lyrics;

--- a/src/main/java/com/windry/chordplayer/domain/SearchCriteria.java
+++ b/src/main/java/com/windry/chordplayer/domain/SearchCriteria.java
@@ -1,0 +1,7 @@
+package com.windry.chordplayer.domain;
+
+public enum SearchCriteria {
+    TITLE,
+    ARTIST,
+//    BPM
+}

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +49,11 @@ public class Song extends BaseEntity {
     private String note;
 
     @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private List<SongGenre> songGenres = new ArrayList<>();
+
+    @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Lyrics> lyricsList = new ArrayList<>();
 
     @Builder
@@ -73,5 +80,9 @@ public class Song extends BaseEntity {
     public void addLyrics(Lyrics lyrics) {
         lyricsList.add(lyrics);
         lyrics.changeSong(this);
+    }
+
+    public void addGenre(SongGenre songGenre) {
+        songGenres.add(songGenre);
     }
 }

--- a/src/main/java/com/windry/chordplayer/domain/SongGenre.java
+++ b/src/main/java/com/windry/chordplayer/domain/SongGenre.java
@@ -1,0 +1,31 @@
+package com.windry.chordplayer.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class SongGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SONG_GENRE_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SONG_ID")
+    private Song song;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "GENRE_ID")
+    private Genre genre;
+
+    @Builder
+    public SongGenre(Song song, Genre genre) {
+        this.song = song;
+        this.genre = genre;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/domain/SortStrategy.java
+++ b/src/main/java/com/windry/chordplayer/domain/SortStrategy.java
@@ -1,0 +1,7 @@
+package com.windry.chordplayer.domain;
+
+public enum SortStrategy {
+    NAME,
+    CHRONOLOGICAL,
+    VIEW
+}

--- a/src/main/java/com/windry/chordplayer/dto/CreateSongDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/CreateSongDto.java
@@ -20,10 +20,10 @@ public class CreateSongDto {
     private String modulation;
     private String note;
     private List<LyricsDto> contents = new ArrayList<>();
-
+    private List<String> genres = new ArrayList<>();
 
     @Builder
-    public CreateSongDto(String title, String artist, String originalKey, Gender gender, int bpm, String modulation, String note, List<LyricsDto> contents) {
+    public CreateSongDto(String title, String artist, String originalKey, Gender gender, int bpm, String modulation, String note, List<LyricsDto> contents, List<String> genres) {
         this.title = title;
         this.artist = artist;
         this.originalKey = originalKey;
@@ -32,5 +32,6 @@ public class CreateSongDto {
         this.modulation = modulation;
         this.note = note;
         this.contents = contents;
+        this.genres = genres;
     }
 }

--- a/src/main/java/com/windry/chordplayer/dto/FiltersOfSongList.java
+++ b/src/main/java/com/windry/chordplayer/dto/FiltersOfSongList.java
@@ -1,0 +1,30 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.domain.Gender;
+import com.windry.chordplayer.domain.SearchCriteria;
+import com.windry.chordplayer.domain.SortStrategy;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class FiltersOfSongList {
+
+    private SearchCriteria searchCriteria;
+    private SortStrategy sortStrategy;
+    private String searchKeyword;
+    private Gender gender;
+    private String searchKey;
+    private String searchGenre;
+
+    @Builder
+    public FiltersOfSongList(SearchCriteria searchCriteria, SortStrategy sortStrategy, String searchKeyword, Gender gender, String searchKey, String searchGenre) {
+        this.searchCriteria = searchCriteria;
+        this.sortStrategy = sortStrategy;
+        this.searchKeyword = searchKeyword;
+        this.gender = gender;
+        this.searchKey = searchKey;
+        this.searchGenre = searchGenre;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/dto/SongListItemDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/SongListItemDto.java
@@ -1,0 +1,35 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.domain.Gender;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class SongListItemDto {
+    private Long songId;
+    private String title;
+    private String artist;
+    private String originalKey;
+    private int bpm;
+    private String modulation;
+    private String note;
+    private Gender gender;
+    private List<String> genres;
+
+    @Builder
+    public SongListItemDto(Long songId, String title, String artist, String originalKey, int bpm, String modulation, String note, Gender gender, List<String> genres) {
+        this.songId = songId;
+        this.title = title;
+        this.artist = artist;
+        this.originalKey = originalKey;
+        this.bpm = bpm;
+        this.modulation = modulation;
+        this.note = note;
+        this.gender = gender;
+        this.genres = genres;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/repository/GenreRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/GenreRepository.java
@@ -1,0 +1,8 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.domain.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+    Genre findGenreByName(String name);
+}

--- a/src/main/java/com/windry/chordplayer/repository/SongRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/SongRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface SongRepository extends JpaRepository<Song, Long> {
+public interface SongRepository extends JpaRepository<Song, Long>, SongRepositoryCustom {
 
     @Query("select s from Song s where replace(s.title, ' ', '') = :title and replace(s.artist, ' ', '') = :artist ")
     Optional<Song> findSongByTitleAndArtist(@Param("title") String title, @Param("artist") String artist);

--- a/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustom.java
+++ b/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.dto.FiltersOfSongList;
+import com.windry.chordplayer.dto.SongListItemDto;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SongRepositoryCustom {
+    List<SongListItemDto> searchAllSong(FiltersOfSongList filtersOfSongList, Pageable pageable);
+}

--- a/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustomImpl.java
+++ b/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustomImpl.java
@@ -1,0 +1,140 @@
+package com.windry.chordplayer.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.windry.chordplayer.domain.*;
+import com.windry.chordplayer.dto.FiltersOfSongList;
+import com.windry.chordplayer.dto.SongListItemDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.windry.chordplayer.domain.QSong.song;
+
+@RequiredArgsConstructor
+public class SongRepositoryCustomImpl implements SongRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SongListItemDto> searchAllSong(FiltersOfSongList filtersOfSongList, Pageable pageable) {
+        List<Song> result = queryFactory
+                .selectFrom(song)
+                .where(
+                        searchByCriteria(filtersOfSongList.getSearchCriteria(),
+                                filtersOfSongList.getSearchKeyword()),
+                        searchByGender(filtersOfSongList.getGender()),
+                        searchByKey(filtersOfSongList.getSearchKey()),
+                        searchByGenre(filtersOfSongList.getSearchGenre())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(sortByStrategy(filtersOfSongList.getSortStrategy()))
+                .fetch();
+        return result.stream().map(r -> {
+            List<String> list = r.getSongGenres().stream().map(g -> g.getGenre().getName()).toList();
+            return SongListItemDto.builder()
+                    .songId(r.getId())
+                    .title(r.getTitle())
+                    .artist(r.getArtist())
+                    .bpm(r.getBpm())
+                    .gender(r.getGender())
+                    .modulation(r.getModulation())
+                    .note(r.getNote())
+                    .originalKey(r.getOriginalKey())
+                    .genres(list)
+                    .build();
+        }).toList();
+    }
+
+    /**
+     * 노래의 키로 검색하기
+     *
+     * @param key 검색할 key
+     * @return 동일한 key 검색
+     */
+    public Predicate searchByKey(String key) {
+        if (key == null)
+            return null;
+
+        return song.originalKey.eq(key);
+    }
+
+    /**
+     * 노래의 성별로 검색하기
+     *
+     * @param gender 검색할 성별
+     * @return 동일한 성별 검색
+     */
+    public Predicate searchByGender(Gender gender) {
+        if (gender == null)
+            return null;
+
+        return song.gender.eq(gender);
+    }
+
+    /**
+     * 노래의 장르로 검색하기 (노래의 장르들 중 포함되는)
+     *
+     * @param genre 검색할 장르
+     * @return 장르 목록 중 포함된 것들 중 검색
+     */
+    public Predicate searchByGenre(String genre) {
+        if (genre == null)
+            return null;
+
+        return song.songGenres.any().genre.name.eq(genre); // 리스트 중 어떤 것이라도 장르의 이름과 동일한 것이 있는지 검사
+    }
+
+    /**
+     * 검색어로 검색하기 (제목, 가수)
+     *
+     * @param criteria 검색 기준
+     * @param keyword  검색할 키워드
+     * @return 키워드가 포함되어있는지 검색
+     */
+    public Predicate searchByCriteria(SearchCriteria criteria, String keyword) {
+        if (criteria == null)
+            return null;
+
+        if (keyword == null)
+            return null;
+
+        switch (criteria) {
+            case TITLE -> {
+                return song.title.contains(keyword);
+            }
+            case ARTIST -> {
+                return song.artist.contains(keyword);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 정렬 전략
+     *
+     * @param sortStrategy 정렬 전략
+     * @return 정렬 구체화
+     */
+    public OrderSpecifier<?> sortByStrategy(SortStrategy sortStrategy) {
+        if (sortStrategy == null)
+            return new OrderSpecifier<>(Order.DESC, song.id);
+
+        switch (sortStrategy) {
+            case CHRONOLOGICAL -> {
+                return new OrderSpecifier<>(Order.DESC, song.id);
+            }
+            case NAME -> {
+                return new OrderSpecifier<>(Order.ASC, song.title);
+            }
+            case VIEW -> {
+                return new OrderSpecifier<>(Order.DESC, song.viewCount);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -1,9 +1,6 @@
 package com.windry.chordplayer.service;
 
-import com.windry.chordplayer.domain.Chords;
-import com.windry.chordplayer.domain.Lyrics;
-import com.windry.chordplayer.domain.Song;
-import com.windry.chordplayer.domain.Tag;
+import com.windry.chordplayer.domain.*;
 import com.windry.chordplayer.dto.CreateSongDto;
 import com.windry.chordplayer.dto.FiltersOfSongList;
 import com.windry.chordplayer.dto.LyricsDto;
@@ -11,6 +8,7 @@ import com.windry.chordplayer.dto.SongListItemDto;
 import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
 import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.repository.ChordsRepository;
+import com.windry.chordplayer.repository.GenreRepository;
 import com.windry.chordplayer.repository.LyricsRepository;
 import com.windry.chordplayer.repository.SongRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +27,7 @@ public class SongService {
     private final SongRepository songRepository;
     private final LyricsRepository lyricsRepository;
     private final ChordsRepository chordsRepository;
+    private final GenreRepository genreRepository;
 
     @Transactional
     public Long createNewSong(CreateSongDto createSongDto) {
@@ -45,6 +44,13 @@ public class SongService {
                 .bpm(createSongDto.getBpm())
                 .build();
 
+        for(int i = 0; i< createSongDto.getGenres().size(); ++i){
+            Genre genre = genreRepository.findGenreByName(createSongDto.getGenres().get(i));
+            SongGenre songGenre = SongGenre.builder()
+                    .genre(genre)
+                    .song(song).build();
+            song.addGenre(songGenre);
+        }
         for (int i = 0; i < createSongDto.getContents().size(); i++) {
             LyricsDto lyricsDto = createSongDto.getContents().get(i);
             Lyrics lyrics = Lyrics.builder()

--- a/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
+++ b/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
@@ -1,11 +1,14 @@
 package com.windry.chordplayer.service;
 
 import com.windry.chordplayer.domain.Gender;
+import com.windry.chordplayer.domain.Genre;
 import com.windry.chordplayer.domain.Song;
+import com.windry.chordplayer.domain.SongGenre;
 import com.windry.chordplayer.dto.CreateSongDto;
 import com.windry.chordplayer.dto.LyricsDto;
 import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
 import com.windry.chordplayer.repository.ChordsRepository;
+import com.windry.chordplayer.repository.GenreRepository;
 import com.windry.chordplayer.repository.LyricsRepository;
 import com.windry.chordplayer.repository.SongRepository;
 import org.junit.jupiter.api.Assertions;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -30,14 +34,19 @@ class SongServiceTest {
     @Autowired
     private ChordsRepository chordsRepository;
     @Autowired
+    private GenreRepository genreRepository;
+    @Autowired
     private SongService songService;
-
 
     @DisplayName("노래 데이터를 생성할 때, 중복되는 제목과 가수가 있을 경우 예외를 발생한다.")
     @Test
     void duplicateSongTitleAndArtistException() {
         // given
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
         Song song = new Song();
+
         CreateSongDto songDto = CreateSongDto.builder()
                 .title("하늘을 달리다")
                 .artist("이적")
@@ -47,6 +56,9 @@ class SongServiceTest {
                 .modulation(null)
                 .contents(null)
                 .build();
+
+        SongGenre songGenre = SongGenre.builder().genre(genre).song(song).build();
+        song.addGenre(songGenre);
 
         song.changeRequestFields(
                 songDto.getTitle(),
@@ -58,6 +70,8 @@ class SongServiceTest {
                 null);
 
         Song differentArtistSong = new Song();
+
+        differentArtistSong.addGenre(songGenre);
         differentArtistSong.changeRequestFields(
                 songDto.getTitle(),
                 "허각",
@@ -73,17 +87,25 @@ class SongServiceTest {
 
         // then
         Assertions.assertEquals("허각", songRepository.findById(2L).get().getArtist());
+        Assertions.assertEquals(1, songRepository.findById(2L).get().getSongGenres().size());
         Assertions.assertThrows(DuplicateTitleAndArtistException.class, () -> songService.validateDupSongAndArtist("하늘을달리다", "이적"));
     }
 
     @DisplayName("4박자 마디의 가사와 코드가 포함된 새로운 노래 데이터를 생성한다.")
     @Test
+    @Rollback(value = false)
     void createNewSong() {
         // given
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
         Song song = new Song();
         song.changeRequestFields(
                 "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
 
         CreateSongDto songDto = CreateSongDto.builder()
                 .title("하늘을 달리다")
@@ -93,6 +115,7 @@ class SongServiceTest {
                 .gender(Gender.MALE)
                 .modulation(null)
                 .contents(null)
+                .genres(genreList)
                 .build();
 
         List<LyricsDto> lyricsDtoList = new ArrayList<>();
@@ -122,10 +145,11 @@ class SongServiceTest {
         // when
         Long newSong = songService.createNewSong(songDto);
 
+        Song song1 = songRepository.findById(newSong).get();
         // then
         org.assertj.core.api.Assertions.assertThat(song)
                 .usingRecursiveComparison()
-                .ignoringFields("createdDate", "modifiedDate", "id", "lyricsList")
-                .isEqualTo(songRepository.findById(newSong).get());
+                .ignoringFields("createdDate", "modifiedDate", "id", "lyricsList", "songGenres")
+                .isEqualTo(song1);
     }
 }


### PR DESCRIPTION
- 노래 목록 조회 API 구현
  - QueryDsl 동적쿼리로 키, 성별, 키워드, 장르 검색 및 정렬 전략 추가
- Genre 엔티티 추가
  - Song 엔티티와의 ManyToMany로 설계하여, 실제로는 SongGenre 엔티티를 추가 도입하여 OneToMany - ManyToOne 관계로 풀어냄
