### PR TITLE
feat: 상세 노래 조회 API 구현하기(필터링)

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -1,13 +1,12 @@
 package com.windry.chordplayer.api;
 
+import com.windry.chordplayer.dto.*;
 import com.windry.chordplayer.spec.Gender;
 import com.windry.chordplayer.spec.SearchCriteria;
 import com.windry.chordplayer.spec.SortStrategy;
-import com.windry.chordplayer.dto.CreateSongDto;
-import com.windry.chordplayer.dto.FiltersOfSongList;
-import com.windry.chordplayer.dto.SongListItemDto;
 import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.service.SongService;
+import com.windry.chordplayer.spec.Tuning;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -34,8 +33,8 @@ public class SongAPI {
 
     @GetMapping("")
     public ResponseEntity<List<SongListItemDto>> getSongList(
-            @RequestParam("page") Integer page,
-            @RequestParam("size") Integer size,
+            @RequestParam("page") Long page,
+            @RequestParam("size") Long size,
             @RequestParam(value = "searchCriteria", required = false) SearchCriteria searchCriteria,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "gender", required = false) Gender gender,
@@ -60,20 +59,40 @@ public class SongAPI {
 
         return ResponseEntity.ok().body(allSongs);
     }
-//
-//    @GetMapping("/{songId}")
-//    public ResponseEntity<Void> getFilteredSong(
-//            @PathVariable("songId") Long songId,
-//            @RequestParam(value = "capo", required = false) int capo,
-//            @RequestParam(value = "tuning", required = false)Tuning tuning,
-//            @RequestParam(value = "gender", required = false) Boolean convertGender,
-//            @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
-//            @RequestParam(value = "key",required = false) int key,
-//            @RequestParam("offset") int offset,
-//            @RequestParam("size") int size
-//            ){
-//
-//    }
+
+    @GetMapping("/{songId}")
+    public ResponseEntity<DetailSongDto> getFilteredSong(
+            @PathVariable("songId") Long songId,
+            @RequestParam(value = "capo", required = false) Integer capo,
+            @RequestParam(value = "tuning", required = false) Tuning tuning,
+            @RequestParam(value = "gender", required = false) Boolean convertGender,
+            @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
+            @RequestParam(value = "key", required = false) Integer key,
+            @RequestParam(value = "currentKey") String currentKey,
+            @RequestParam("offset") Long offset, // line 에 대한 offset
+            @RequestParam("size") Long size
+    ) {
+
+        if (songId == null)
+            throw new InvalidInputException();
+
+        if (offset == null || size == null)
+            throw new InvalidInputException();
+
+        if(currentKey == null)
+            throw new InvalidInputException();
+
+        FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
+                .capo(capo)
+                .tuning(tuning)
+                .convertGender(convertGender)
+                .isKeyUp(isKeyUp)
+                .key(key)
+                .build();
+
+        DetailSongDto detailSong = songService.getDetailSong(songId, offset, size, filters, currentKey);
+        return ResponseEntity.ok().body(detailSong);
+    }
 //
 //    @PutMapping("/{songId}")
 //    public ResponseEntity<Void> modifySong(){

--- a/src/main/java/com/windry/chordplayer/domain/Chords.java
+++ b/src/main/java/com/windry/chordplayer/domain/Chords.java
@@ -29,6 +29,5 @@ public class Chords extends BaseEntity {
 
     public void changeLyrics(Lyrics lyrics) {
         this.lyrics = lyrics;
-        lyrics.getChords().add(this);
     }
 }

--- a/src/main/java/com/windry/chordplayer/domain/Lyrics.java
+++ b/src/main/java/com/windry/chordplayer/domain/Lyrics.java
@@ -46,7 +46,6 @@ public class Lyrics extends BaseEntity {
 
     public void changeSong(Song song){
         this.song = song;
-        song.getLyricsList().add(this);
     }
 
     public void addChords(Chords chord){

--- a/src/main/java/com/windry/chordplayer/dto/DetailLyricsDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/DetailLyricsDto.java
@@ -1,0 +1,27 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.spec.Tag;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class DetailLyricsDto {
+
+    private Integer line;
+    private String lyrics;
+    private Tag tag;
+    private List<String> chords = new ArrayList<>();
+
+    @Builder
+    public DetailLyricsDto(Integer line, String lyrics, Tag tag, List<String> chords) {
+        this.line = line;
+        this.lyrics = lyrics;
+        this.tag = tag;
+        this.chords = chords;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/dto/DetailSongDto.java
+++ b/src/main/java/com/windry/chordplayer/dto/DetailSongDto.java
@@ -1,0 +1,29 @@
+package com.windry.chordplayer.dto;
+
+import com.windry.chordplayer.spec.Gender;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class DetailSongDto {
+
+    private String title;
+    private String artist;
+    private String currentKey;
+    private Gender gender;
+    private List<DetailLyricsDto> contents = new ArrayList<>();
+
+    @Builder
+    public DetailSongDto(String title, String artist, String currentKey, Gender gender, List<DetailLyricsDto> contents) {
+        this.title = title;
+        this.artist = artist;
+        this.currentKey = currentKey;
+        this.gender = gender;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/dto/FiltersOfDetailSong.java
+++ b/src/main/java/com/windry/chordplayer/dto/FiltersOfDetailSong.java
@@ -1,0 +1,28 @@
+package com.windry.chordplayer.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.windry.chordplayer.spec.Tuning;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class FiltersOfDetailSong {
+
+    private Integer capo;
+    private Tuning tuning;
+    private Boolean convertGender;
+    @JsonProperty("isKeyUp")
+    private Boolean isKeyUp;
+    private Integer key;
+
+    @Builder
+    public FiltersOfDetailSong(Integer capo, Tuning tuning, Boolean convertGender, Boolean isKeyUp, Integer key) {
+        this.capo = capo;
+        this.tuning = tuning;
+        this.convertGender = convertGender;
+        this.isKeyUp = isKeyUp;
+        this.key = key;
+    }
+}

--- a/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
+++ b/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     INVALID_PARAMETER("4002", "요구되는 입력 값이 유효하지 않거나 존재하지 않습니다."),
     INVALID_CHORD_MATCH("4003", "존재하지 않는 코드 형태입니다."),
     DUPLICATE_GENRE_NAME("4004", "이미 존재하는 장르 이름입니다."),
-    NO_SUCH_ELEMENT("4005", "존재하지 않는 데이터입니다.");
+    NO_SUCH_ELEMENT("4005", "존재하지 않는 데이터입니다."),
+    IMPOSSIBLE_MIXED_GENDER_CONVERT("4006", "혼성 키는 키 변경이 불가능합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/windry/chordplayer/exception/ImpossibleConvertGenderException.java
+++ b/src/main/java/com/windry/chordplayer/exception/ImpossibleConvertGenderException.java
@@ -1,0 +1,9 @@
+package com.windry.chordplayer.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ImpossibleConvertGenderException extends CustomRuntimeException {
+    public ImpossibleConvertGenderException() {
+        super(HttpStatus.FORBIDDEN, ErrorCode.IMPOSSIBLE_MIXED_GENDER_CONVERT);
+    }
+}

--- a/src/main/java/com/windry/chordplayer/repository/LyricsRepository.java
+++ b/src/main/java/com/windry/chordplayer/repository/LyricsRepository.java
@@ -3,5 +3,5 @@ package com.windry.chordplayer.repository;
 import com.windry.chordplayer.domain.Lyrics;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LyricsRepository extends JpaRepository<Lyrics, Long> {
+public interface LyricsRepository extends JpaRepository<Lyrics, Long>, LyricsRepositoryCustom {
 }

--- a/src/main/java/com/windry/chordplayer/repository/LyricsRepositoryCustom.java
+++ b/src/main/java/com/windry/chordplayer/repository/LyricsRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.windry.chordplayer.repository;
+
+import com.windry.chordplayer.dto.DetailLyricsDto;
+
+import java.util.List;
+
+public interface LyricsRepositoryCustom {
+
+    List<DetailLyricsDto> getPagingLyricsBySong(Long offset, Long size, Long songId);
+}

--- a/src/main/java/com/windry/chordplayer/repository/LyricsRepositoryCustomImpl.java
+++ b/src/main/java/com/windry/chordplayer/repository/LyricsRepositoryCustomImpl.java
@@ -1,0 +1,49 @@
+package com.windry.chordplayer.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.windry.chordplayer.domain.Lyrics;
+import com.windry.chordplayer.dto.DetailLyricsDto;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.windry.chordplayer.domain.QChords.chords;
+import static com.windry.chordplayer.domain.QLyrics.lyrics1;
+
+@RequiredArgsConstructor
+public class LyricsRepositoryCustomImpl implements LyricsRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DetailLyricsDto> getPagingLyricsBySong(Long offset, Long size, Long songId) {
+        List<Lyrics> lyrics = queryFactory
+                .selectFrom(lyrics1)
+                .join(lyrics1.chords, chords).fetchJoin()
+                .where(
+                        pagination(offset),
+                        lyrics1.song.id.eq(songId)
+                )
+                .limit(size)
+                .orderBy(new OrderSpecifier<>(Order.ASC, lyrics1.line))
+                .fetch();
+        return lyrics.stream().map(l ->
+                DetailLyricsDto.builder()
+                        .tag(l.getTag())
+                        .line(l.getLine())
+                        .chords(l.convertStringChords(l.getChords()))
+                        .lyrics(l.getLyrics())
+                        .build()
+        ).toList();
+    }
+
+    private Predicate pagination(Long offset) {
+        if (offset == null || offset == 0L) {
+            return null;
+        }
+        return lyrics1.id.gt(offset);
+    }
+}

--- a/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustom.java
+++ b/src/main/java/com/windry/chordplayer/repository/SongRepositoryCustom.java
@@ -1,11 +1,11 @@
 package com.windry.chordplayer.repository;
 
+import com.windry.chordplayer.domain.Song;
 import com.windry.chordplayer.dto.FiltersOfSongList;
 import com.windry.chordplayer.dto.SongListItemDto;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface SongRepositoryCustom {
-    List<SongListItemDto> searchAllSong(FiltersOfSongList filtersOfSongList, Pageable pageable);
+    List<SongListItemDto> searchAllSong(FiltersOfSongList filtersOfSongList, Long page, Long size, Song cursorSong);
 }

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -3,6 +3,7 @@ package com.windry.chordplayer.service;
 import com.windry.chordplayer.domain.*;
 import com.windry.chordplayer.dto.*;
 import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
+import com.windry.chordplayer.exception.ImpossibleConvertGenderException;
 import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.exception.NoSuchDataException;
 import com.windry.chordplayer.repository.ChordsRepository;
@@ -124,6 +125,8 @@ public class SongService {
                     currentGender = Gender.MALE;
                 }
                 cumulateKey += amount;
+            } else {
+                throw new ImpossibleConvertGenderException();
             }
         }
 

--- a/src/main/java/com/windry/chordplayer/util/ChordUtil.java
+++ b/src/main/java/com/windry/chordplayer/util/ChordUtil.java
@@ -1,4 +1,4 @@
-package com.windry.chordplayer.dto;
+package com.windry.chordplayer.util;
 
 import com.windry.chordplayer.exception.NotFoundChordException;
 

--- a/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
+++ b/src/test/java/com/windry/chordplayer/dto/ChordUtilTest.java
@@ -1,5 +1,6 @@
 package com.windry.chordplayer.dto;
 
+import com.windry.chordplayer.util.ChordUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
+++ b/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
@@ -1,5 +1,8 @@
 package com.windry.chordplayer.service;
 
+import com.windry.chordplayer.dto.DetailSongDto;
+import com.windry.chordplayer.dto.FiltersOfDetailSong;
+import com.windry.chordplayer.exception.ImpossibleConvertGenderException;
 import com.windry.chordplayer.spec.Gender;
 import com.windry.chordplayer.domain.Genre;
 import com.windry.chordplayer.domain.Song;
@@ -11,12 +14,12 @@ import com.windry.chordplayer.repository.ChordsRepository;
 import com.windry.chordplayer.repository.GenreRepository;
 import com.windry.chordplayer.repository.LyricsRepository;
 import com.windry.chordplayer.repository.SongRepository;
+import com.windry.chordplayer.spec.Tuning;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -93,7 +96,6 @@ class SongServiceTest {
 
     @DisplayName("4박자 마디의 가사와 코드가 포함된 새로운 노래 데이터를 생성한다.")
     @Test
-    @Rollback(value = false)
     void createNewSong() {
         // given
         Genre genre = Genre.builder().name("락").build();
@@ -151,5 +153,174 @@ class SongServiceTest {
                 .usingRecursiveComparison()
                 .ignoringFields("createdDate", "modifiedDate", "id", "lyricsList", "songGenres")
                 .isEqualTo(song1);
+    }
+
+    @Test
+    @DisplayName("상세 노래 정보에서 키 변경에 대한 여러가지 필터를 적용해본다.")
+    void changeKeyOfDetailSong() {
+        // given
+        Genre genre = Genre.builder().name("발라드").build();
+        genreRepository.save(genre);
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("발라드");
+
+        CreateSongDto songDto = CreateSongDto.builder()
+                .title("다정히 내 이름을 부르면")
+                .artist("경서예지")
+                .originalKey("Db")
+                .bpm(72)
+                .gender(Gender.MIXED)
+                .modulation("Db-Eb-F-G")
+                .contents(null)
+                .genres(genreList)
+                .build();
+
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("Db", "Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("Bbm7", "Fm7"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("Gb", "Gbm6"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("끝 없")
+                .chords(LyricsDto.getAllChords("Db", "Dbsus4", "Db"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("이 별빛이 내리던 밤")
+                .chords(LyricsDto.getAllChords("Db", "Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("기분 좋은 바람이")
+                .chords(LyricsDto.getAllChords("Bbm7", "Db/Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두 뺨을 스치고")
+                .chords(LyricsDto.getAllChords("Gb", "Db/F"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("새벽 바다 한 곳을 보")
+                .chords(LyricsDto.getAllChords("Ebm", "Gb/Ab", "Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("는 아름다운 너와 나")
+                .chords(LyricsDto.getAllChords("Db", "Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("그림을 그려갔어")
+                .chords(LyricsDto.getAllChords("Bbm", "Bbm7/Ab"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("모래 위 떨린 손")
+                .chords(LyricsDto.getAllChords("Gbm", "Gbm6"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("끝으로 날 향")
+                .chords(LyricsDto.getAllChords("Db", "Fm/C"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("해 웃어주는 입술")
+                .chords(LyricsDto.getAllChords("Bbm", "BbmM7/A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("사랑스러운 두눈을 가진 네")
+                .chords(LyricsDto.getAllChords("Ebm", "Db/F", "Gb", "Eb7/G"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("MODULATION")
+                .lyrics("가 다정히 내 이름을")
+                .chords(LyricsDto.getAllChords("Ab", "Bb"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("부르면 내 마음이")
+                .chords(LyricsDto.getAllChords("Eb", "Bb"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("녹아내려 언제나")
+                .chords(LyricsDto.getAllChords("Cm", "Cm7/Bb"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("나 하날 위해 준비된")
+                .chords(LyricsDto.getAllChords("Ab", "Eb/G"))
+                .build());
+
+        songDto.setContents(lyricsDtoList);
+
+        // when
+        Long newSong = songService.createNewSong(songDto);
+
+        FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
+                .key(null)
+                .isKeyUp(null)
+                .convertGender(null)
+                .tuning(null)
+                .capo(1)
+                .build();
+
+        FiltersOfDetailSong filters2 = FiltersOfDetailSong.builder()
+                .key(3)
+                .isKeyUp(true)
+                .convertGender(null)
+                .tuning(null)
+                .capo(1)
+                .build();
+
+        FiltersOfDetailSong filters3 = FiltersOfDetailSong.builder()
+                .key(null)
+                .isKeyUp(null)
+                .convertGender(true)
+                .tuning(null)
+                .capo(null)
+                .build();
+
+        FiltersOfDetailSong filters4 = FiltersOfDetailSong.builder()
+                .key(null)
+                .isKeyUp(null)
+                .convertGender(null)
+                .tuning(Tuning.HALF_STEP)
+                .capo(null)
+                .build();
+
+        DetailSongDto detailSong = songService.getDetailSong(1L, 0L, 10L, filters, "Db");
+        DetailSongDto detailSong2 = songService.getDetailSong(1L, 0L, 20L, filters, "Db");
+        DetailSongDto detailSong3 = songService.getDetailSong(1L, 0L, 20L, filters2, "Db");
+        DetailSongDto detailSong5 = songService.getDetailSong(1L, 0L, 10L, filters4, "Db");
+
+        // then
+        Assertions.assertEquals(10, detailSong.getContents().size());
+        Assertions.assertEquals("C", detailSong.getCurrentKey());
+        Assertions.assertEquals("D", detailSong2.getCurrentKey());
+        Assertions.assertEquals("F", detailSong3.getCurrentKey());
+        Assertions.assertEquals("C", detailSong5.getCurrentKey());
+
+        Assertions.assertThrows(ImpossibleConvertGenderException.class, () -> songService.getDetailSong(1L, 0L, 10L, filters3, "Db"));
+
+        Assertions.assertEquals("C", detailSong.getContents().get(0).getChords().get(0));
+        Assertions.assertEquals("G", detailSong.getContents().get(0).getChords().get(1));
+        Assertions.assertEquals("Am7", detailSong.getContents().get(1).getChords().get(0));
     }
 }


### PR DESCRIPTION
- 노래 목록과 상세 노래에서의 가사 목록을 위한 페이지네이션을 다시 제대로 구현함.
  - offset 데이터를 입력받아서, 이 값을 기준으로 삼아 이 다음의 데이터를 size만큼 끌어오기 위해 queryDsl의 `lt` 메소드를 사용하였다.
  - 또한 노래 목록에서는 목록 조회 기준이 시간순, 이름순, 조회순이라는 여러 기준이 있어서 각 정렬 기준에 따라 현재 데이터를 기준으로 삼아 해당 정렬 기준의 다음 데이터부터 끌어오도록 사용하였다. 여기서 이름과 조회는 `loe`(less than or equal to 연산자)를 사용하였다.
- 노래 목록을 조회할 때, 장르 데이터도 같이 끌어왔어야했기 때문에 Genre 엔티티와 Join하는 동적 쿼리를 생성하였다. (그래서 장르 데이터 없이 노래 데이터를 만들면 노래 데이터는 조회 불가능)
- 상세 노래 조회 로직
  - 각 필터링 데이터가 null이 아니면(= 존재하면) 해당 기준마다의 키 변경 정수 값을 도출해서 그 값만큼 키 변경 유틸 메소드로 모든 코드를 변경시키려고 했다.
  - 여기서 키 변경을 할 때, 가사 데이터의 각 모든 코드 데이터를 조회하면서 `set()` 메소드로 기존 코드를 키 변경한 코드로 변경하려고 했으나 `UnsupportedOperationException`이 발생하였다. 
  - 원인을 알아보니 List 자체는 element 자체가 immutable하다는 것이다. 그래서 List 데이터를 ArrayList 타입으로 캐스팅한 뒤, `replaceAll()` 메소드로 모든 코드를 각 키 변경한 코드로 변경 시켜준 다음에 현재 가사 데이터의 코드를 재설정하는 방식으로 해주었다. 
  - 또한, 모든 필터마다 키 변경 메소드를 호출해주었는데, 이 방식은 비효율적이라고 판단되어서 각 필터링에서 얻어지는 키 변경 정수 값을 모두 합치고나서 한번만 그 값만큰 키 변경을 하도록 수정했다.
  - 그리고 노래마다 다르지만 전조가 한번 있는 것이 아니라 2번 이상 있는 노래의 경우에는 현재 key 값을 계산해줬어야했기 때문에 추가적인 요청 입력으로 현재 key 값을 받고, 노래 데이터를 저장할 때 입력한 modulation 필드 값을 추출하여 현재 키의 위치를 찾도록 하고, 현재 마디가 MODULATION이면 다음 키로 이동해야되기 때문에 해당 코드를 반환해주도록 했다. 
- 테스트 코드
  - Postman으로 테스트할 때는 각 마디 가사의 코드가 중복 없이 잘 나왔는데, 테스트 코드로 작성했을 때는 코드가 중복되서 조회가 되었다;; (expected: [Db, Ab] , actual: [Db, Db, Ab, Ab])
  - 엥 그런 로직이 어디있지 생각하고 트랜잭션의 롤백을 false로 하기 위해 @RollBack(value= false) 어노테이션을 사용했는데, `UnexpectedRollbackException`가 발생했다. 
  - 그래서 해결방법을 찾아보다가 @Transaction(propagation = Propagation.NOT_SUPPORTED) 를 사용했는데도 발생해서, 문득 데이터베이스 연결 때문인가 싶었다. 테스트코드의 application.yml 파일이 없으면 기본 인메모리 DB로 사용하는 것으로 알고 있다.
  - 그래서 test 폴더의 application.yml를 추가하여 MySQL 드라이버를 연결해주고 다시 실행했더니, 확실히 롤백이 되지 않았다. 
  - 근데? 데이터는 중복되지 않고 잘 저장이 된 것을 볼 수 있었다;;
  - 테스트 시에는 롤백을 반드시해야되는데 이것은 반드시 해결해야겠다는 생각으로 서비스 로직을 하나하나 뒤져보기로 했다.
  - 순수 출력 디버깅 노가다를 통해 중복 부분을 찾게 되었는데, 그 부분은 바로 노래 데이터를 저장할 때, 코드와 가사 엔티티의 연관관계 메소드 호출 시, List에 두번 들어가는 것을 확인했다. 이는 Cascade 효과를 보기 위해 사용한 것인데, 가사 엔티티에서 addChords()를 호출하는데 여기서 가사 엔티티의 chords 리스트에 chords 데이터를 추가하고, chords의 lyrics를 자기자신으로 설정하는 것이였는데, 여기서 chords의 lyrics를 자기자신으로 설정하는 메소드를 호출할 때, 이 메소드에서 **또** lyrics의 코드에 자기자신(chords)를 추가하고 있던 것이였다!.... 이런 형태가 가사<->코드 뿐만 아니라 노래<->가사에도 적용이 되어있어서 중복 추가 로직을 제거했다. 그랬더니 테스트 코드 상에서도 아주 잘 작동하게 되었다
- 혼성 키일 때 키 변경하려고 하면 예외가 터지도록 추가 조치를 하였다