### PR TITLE
feat: 노래 수정 API 구현

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -79,7 +79,7 @@ public class SongAPI {
         if (offset == null || size == null)
             throw new InvalidInputException();
 
-        if(currentKey == null)
+        if (currentKey == null)
             throw new InvalidInputException();
 
         FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
@@ -93,12 +93,16 @@ public class SongAPI {
         DetailSongDto detailSong = songService.getDetailSong(songId, offset, size, filters, currentKey);
         return ResponseEntity.ok().body(detailSong);
     }
-//
-//    @PutMapping("/{songId}")
-//    public ResponseEntity<Void> modifySong(){
-//
-//    }
-//
+
+    @PutMapping("/{songId}")
+    public ResponseEntity<Void> modifySong(
+            @PathVariable("songId") Long songId,
+            @RequestBody CreateSongDto createSongDto
+    ) {
+        songService.modifySong(songId, createSongDto);
+        return ResponseEntity.ok().build();
+    }
+
 //    @DeleteMapping("/{songId}")
 //    public ResponseEntity<Void> deleteSong(){
 //

--- a/src/main/java/com/windry/chordplayer/domain/Chords.java
+++ b/src/main/java/com/windry/chordplayer/domain/Chords.java
@@ -30,4 +30,8 @@ public class Chords extends BaseEntity {
     public void changeLyrics(Lyrics lyrics) {
         this.lyrics = lyrics;
     }
+
+    public void updateChord(String chord) {
+        this.chord = chord;
+    }
 }

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -49,11 +49,11 @@ public class Song extends BaseEntity {
 
     private String note;
 
-    @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "song", cascade = CascadeType.ALL, orphanRemoval = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<SongGenre> songGenres = new ArrayList<>();
 
-    @OneToMany(mappedBy = "song", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "song", cascade = CascadeType.ALL, orphanRemoval = true)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Lyrics> lyricsList = new ArrayList<>();
 
@@ -68,14 +68,51 @@ public class Song extends BaseEntity {
         this.note = note;
     }
 
-    public void changeRequestFields(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation, List<Lyrics> lyrics) {
+    public void changeRequestFields(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation, List<Lyrics> lyrics, List<SongGenre> songGenres) {
         this.title = title;
         this.artist = artist;
         this.originalKey = originalKey;
         this.gender = gender;
         this.bpm = bpm;
         this.modulation = modulation;
-        this.lyricsList = lyrics;
+
+        if(lyrics != null) {
+            // 가사 업데이트
+            for (int i = 0; i < this.lyricsList.size(); ++i) {
+                if (i < lyrics.size()) {
+                    Lyrics exist = this.lyricsList.get(i);
+                    Lyrics updated = lyrics.get(i);
+                    exist.updateLyrics(updated.getTag(), updated.getLyrics(), updated.getChords());
+                } else {
+                    this.lyricsList.remove(i);
+                    i--;
+                }
+            }
+
+            for (int i = this.lyricsList.size(); i < lyrics.size(); ++i) {
+                Lyrics lyrics1 = lyrics.get(i);
+                this.lyricsList.add(lyrics1);
+            }
+        }
+
+        if(songGenres != null) {
+            // 장르 업데이트
+            for (int i = 0; i < this.songGenres.size(); ++i) {
+                if (i < songGenres.size()) {
+                    SongGenre exist = this.songGenres.get(i);
+                    SongGenre updated = songGenres.get(i);
+                    exist.changeSongGenre(updated.getGenre());
+                } else {
+                    this.songGenres.remove(i); // orphanRemoval 속성!!
+                    i--;
+                }
+            }
+
+            for (int i = this.songGenres.size(); i < songGenres.size(); ++i) {
+                SongGenre songGenre = songGenres.get(i);
+                this.songGenres.add(songGenre);
+            }
+        }
     }
 
     public void addLyrics(Lyrics lyrics) {
@@ -87,7 +124,7 @@ public class Song extends BaseEntity {
         songGenres.add(songGenre);
     }
 
-    public void updateViewCount(){
+    public void updateViewCount() {
         this.viewCount++;
     }
 }

--- a/src/main/java/com/windry/chordplayer/domain/SongGenre.java
+++ b/src/main/java/com/windry/chordplayer/domain/SongGenre.java
@@ -28,4 +28,8 @@ public class SongGenre {
         this.song = song;
         this.genre = genre;
     }
+
+    public void changeSongGenre(Genre genre) {
+        this.genre = genre;
+    }
 }


### PR DESCRIPTION
- 테스트 코드 수정
  - 서비스 테스트 전체를 돌렸더니, 존재하지 않는 데이터 exception이 발생해서 봤더니, 노래 데이터를 조회할 때, 조회할 ID 값을 하드코딩을 해놨었다. 기존에 쌓인 데이터나 다른 테스트 메소드에 영향을 받나 싶어서 해당 테스트에서 가져온 ID 변수 값을 할당해주는 방식으로 수정했다.
  - 노래 수정 서비스 로직 테스트를 하기 위해 노래 생성을 위한 DTO와 노래 수정을 위한 DTO 두가지를 만들어놨는데, 복붙의 위험성을 느꼈다. Lyrics에 대한 DTO에 데이터를 추가할 때, 수정을 위한 객체가 아니라 생성에 대한 객체에 데이터를 추가해놓고, 그대로 수정 서비스를 호출했어서 수정된 데이터를 조회했을 때, 노래 데이터에 가사 데이터가 전혀 포함되어있지 않아있었다..(null이 아닌 그냥 빈 리스트) 그래서 지연 로딩, 즉시 로딩의 문제인가 싶어서 페치 전략도 바꿔보고, @EntityGraph도 사용해보고 했었었다. 하지만? 그냥 변수명을 잘못보고 진짜 데이터를 안넣은 상태로 수정해서 그런 거였다.. (덕분에 장르, 가사 둘다 지연 로딩을 직접적으로 볼 수 있었다. -> 쿼리문이 안나가다가 엔티티를 호출하자마자 select 쿼리가 나감!)
  - 노래 데이터를 생성하고 나서 수정한 뒤, 그 결과를 조회하고 싶은데, 그렇기에는 트랜잭션을 다 끝내고 DB에 반영을 해야만 했다. 그래서 EntityManager를 DI하고 flush와 clear를 해주고나서 수정한 노래 데이터를 조회했다.
    - 여기서 Intellij 상에서 EntityManager에 @Autowired를 하면 컴파일 에러가 발생하는데, 무시해도 된다고 한다. 
  - 중복된 제목과 가수에 대한 중복 테스트 코드가 갑자기 fail이 떠서 보니까 잘못된 값으로 assert 비교를 하고 있었다.. (전에는 왜 성공한거지?..) 그래서 수정해줬다.  

- 노래 수정 API 서비스 로직
  - JPA 상에서 update는 따로 repository 상에서 update 쿼리를 호출하지 않고, 엔티티의 필드 값을 바꾸면 트랜잭션이 종료될 때, 자동으로 update 쿼리가 나간다. 
  - 그래서 연관관계가 있어도 단순 필드 값만 재할당해주면 될 것이라고 생각했다. DTO에서 장르 데이터와 가사 데이터를 추출하고 엔티티 객체를 만든 다음 PathVariable을 통해 조회한 Song 데이터의 각 필드에 할당해주었는데, 데이터베이스를 보니 오히려 수정이 아니라 데이터가 "생성"되었다!....
  - 찾아보니, 새로운 엔티티 객체를 생성하고 할당하는 것은 JPA에서 데이터를 새로운 데이터로 인식하고 새로운 엔티티로써 데이터베이스에 insert한다고 한다. 
  - 즉, 기존 데이터는 남아있는 상태에서 새롭게 데이터를 추가해준 셈이였다. 그래서 Song 엔티티에 Lyrics 엔티티와 수정을 하는 연관관계 편의 메소드에서 기존 가사 리스트의 크기만큼은 새로운 데이터로 교체해주고, 만약 exist > new 라면 가사 리스트에서 엔티티를 remove 해주고, 만약 exist < new 라면 차이만큼 새로운 데이터를 add해준다.
    - 여기서 교체해줄 때도 Lyrics 엔티티의 업데이트를 위한 연관관계 편의 메소드를 정의해줬다. 그럼 꼬리 물기처럼 Chords 엔티티도 똑같이 Song <-> Lyrics 와 동일하게 연관관계 메소드를 정의해준다. 
  - 그래서 수정은 잘 되는 것을 확인했는데, exist > new 인 상황에서 remove를 해주는데, 실제 데이터베이스 상에서는 데이터가 지워지지 않는 현상이 있었다. 
  - 찾아보니 OneToMany 연관관계의 속성 중에서 `orphanRemoval` 속성이 있었다. 이는 부모 엔티티와 연관관계가 끊어진 자식 엔티티를 자동으로 삭제해주는 역할을 해준다. 즉, 가사 리스트에서 remove() 메소드를 통해 자식인 Lyrics 엔티티를 끊어주었다. 해당 엔티티는 자동으로 트랜잭션이 종료될 때 delete 쿼리문이 나가게 된다. 
  - 그래서 이를 모두 적용하게 하기 위해, Song 엔티티의 SongGenre와 Lyrics 엔티티에도 `orphanRemoval` 속성을 추가해주었고, Lyrics 엔티티의 Chords 엔티티에도 추가해주었다.  

`페치 전략! orphanRemoval! 복붙 위험! JPA 수정!`