### PR TITLE
feat: 노래 삭제 API 구현

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -103,9 +103,12 @@ public class SongAPI {
         return ResponseEntity.ok().build();
     }
 
-//    @DeleteMapping("/{songId}")
-//    public ResponseEntity<Void> deleteSong(){
-//
-//    }
+    @DeleteMapping("/{songId}")
+    public ResponseEntity<Void> deleteSong(
+            @PathVariable("songId") Long songId
+    ) {
+        songService.removeSongData(songId);
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -76,7 +76,7 @@ public class Song extends BaseEntity {
         this.bpm = bpm;
         this.modulation = modulation;
 
-        if(lyrics != null) {
+        if (lyrics != null) {
             // 가사 업데이트
             for (int i = 0; i < this.lyricsList.size(); ++i) {
                 if (i < lyrics.size()) {
@@ -95,7 +95,7 @@ public class Song extends BaseEntity {
             }
         }
 
-        if(songGenres != null) {
+        if (songGenres != null) {
             // 장르 업데이트
             for (int i = 0; i < this.songGenres.size(); ++i) {
                 if (i < songGenres.size()) {

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -164,13 +164,14 @@ public class SongService {
 
     @Transactional
     public void modifySong(Long songId, CreateSongDto createSongDto) {
-        if (songRepository.findById(songId).isEmpty())
+        Optional<Song> optional = songRepository.findById(songId);
+        if (optional.isEmpty())
             throw new NoSuchDataException();
 
         if (createSongDto == null)
             throw new InvalidInputException();
 
-        Song song = songRepository.findById(songId).get();
+        Song song = optional.get();
 
         List<SongGenre> songGenres = new ArrayList<>();
         for (int i = 0; i < createSongDto.getGenres().size(); ++i) {
@@ -205,6 +206,16 @@ public class SongService {
                 lyricsList,
                 songGenres
         );
+    }
+
+    @Transactional
+    public void removeSongData(Long songId) {
+        Optional<Song> optional = songRepository.findById(songId);
+        if (optional.isEmpty())
+            throw new NoSuchDataException();
+
+        Song song = optional.get();
+        songRepository.delete(song);
     }
 
     private String findNextModulationKey(String curKey, Song song, List<DetailLyricsDto> lyrics) {


### PR DESCRIPTION
- 노래 삭제 API 구현
  - 연관관계의 `Cascade.ALL`과 `orphanRemoval` 속성 덕분에 그냥 깔끔하게 Song 엔티티만 지우면 끝^^
- 테스트 코드
  - 더미 데이터 하나 만들어 놓고, entityManager로 flush & clear 한 뒤, 조회했을 때 exception이 발생하면 성공하도록 했다. 