### PR TITLE
test: MockMvc를 사용한 API 테스트

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -33,8 +33,8 @@ public class SongAPI {
 
     @GetMapping("")
     public ResponseEntity<List<SongListItemDto>> getSongList(
-            @RequestParam("page") Long page,
-            @RequestParam("size") Long size,
+            @RequestParam(value = "page", defaultValue = "1") Long page,
+            @RequestParam(value = "size", defaultValue = "10") Long size,
             @RequestParam(value = "searchCriteria", required = false) SearchCriteria searchCriteria,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "gender", required = false) Gender gender,
@@ -69,8 +69,8 @@ public class SongAPI {
             @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
             @RequestParam(value = "key", required = false) Integer key,
             @RequestParam(value = "currentKey") String currentKey,
-            @RequestParam("offset") Long offset, // line 에 대한 offset
-            @RequestParam("size") Long size
+            @RequestParam(value = "offset", defaultValue = "0") Long offset, // line 에 대한 offset
+            @RequestParam(value = "size", defaultValue = "20") Long size
     ) {
 
         if (songId == null)

--- a/src/test/java/com/windry/chordplayer/api/GenreAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/GenreAPITest.java
@@ -1,0 +1,98 @@
+package com.windry.chordplayer.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.windry.chordplayer.domain.Genre;
+import com.windry.chordplayer.dto.CreateGenreDto;
+import com.windry.chordplayer.repository.GenreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class GenreAPITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @DisplayName("장르 데이터를 저장한다.")
+    @Test
+    void createGenre() throws Exception {
+        CreateGenreDto dto = CreateGenreDto.builder()
+                .name("발라드").build();
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        this.mockMvc.perform(post("/api/genres")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+    }
+
+    @DisplayName("이미 존재하는 장르 이름으로 생성하는 경우 예외가 발생한다.")
+    @Test
+    void duplicateGenreName() throws Exception {
+        Genre genre = Genre.builder().name("발라드").build();
+        genreRepository.save(genre);
+
+        CreateGenreDto dto = CreateGenreDto.builder()
+                .name("발라드").build();
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        this.mockMvc.perform(post("/api/genres")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError());
+
+    }
+
+    @DisplayName("장르 데이터를 삭제한다.")
+    @Test
+    void deleteGenre() throws Exception {
+        Genre genre = Genre.builder().name("발라드").build();
+        Long genreId = genreRepository.save(genre).getId();
+
+        this.mockMvc.perform(delete("/api/genres/" + genreId))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 장르 데이터에 대해 삭제 시도 시, 예외가 발생한다.")
+    @Test
+    void deleteGenreNotExist() throws Exception {
+        Genre genre = Genre.builder().name("발라드").build();
+        Long genreId = genreRepository.save(genre).getId();
+
+        this.mockMvc.perform(delete("/api/genres/" + (genreId + 1)))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @DisplayName("장르 전체 목록을 조회한다.")
+    @Test
+    void getGenreList() throws Exception {
+        this.mockMvc.perform(get("/api/genres"))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -1,0 +1,450 @@
+package com.windry.chordplayer.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.windry.chordplayer.domain.Genre;
+import com.windry.chordplayer.domain.Song;
+import com.windry.chordplayer.domain.SongGenre;
+import com.windry.chordplayer.dto.CreateSongDto;
+import com.windry.chordplayer.dto.LyricsDto;
+import com.windry.chordplayer.repository.GenreRepository;
+import com.windry.chordplayer.repository.SongRepository;
+import com.windry.chordplayer.spec.Gender;
+import com.windry.chordplayer.spec.SearchCriteria;
+import com.windry.chordplayer.spec.SortStrategy;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class SongAPITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private SongRepository songRepository;
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @DisplayName("이미 존재하는 제목과 가수의 노래를 생성할 때, 예외를 발생한다.")
+    @Test
+    void createSongWithException() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        songRepository.save(song);
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("이적")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        dto.setContents(lyricsDtoList);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        System.out.println("response.getContentAsString() = " + response.getContentAsString());
+    }
+
+    @DisplayName("제목은 중복되도 가수 이름이 다르면 성공적으로 노래가 생성된다.")
+    @Test
+    void createSong() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        songRepository.save(song);
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("허각")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        dto.setContents(lyricsDtoList);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        System.out.println("response.getContentAsString() = " + response.getContentAsString());
+    }
+
+
+    @DisplayName("노래 목록을 조회할 때, 모든 필터를 적용해본다. ")
+    @Test
+    public void getSongListWithAllFilters() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        Long id = songRepository.save(song).getId();
+
+        MvcResult mvcResult = this.mockMvc.perform(get("/api/songs")
+                .param("page", id.toString())
+                .param("size", "10")
+                .param("searchCriteria", "TITLE")
+                .param("keyword", "하늘")
+                .param("gender", "MALE")
+                .param("key", "E")
+                .param("genre", "락")
+        ).andExpect(status().isOk()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String content = response.getContentAsString();
+        System.out.println("content = " + content);
+
+        JSONArray jsonArray = new JSONArray(content);
+
+        assertTrue(jsonArray.length() > 0);
+    }
+
+    @DisplayName("노래 목록을 조회할 때 커서에 해당하는 데이터가 존재하지 않으면 예외를 발생한다.")
+    @Test
+    public void getSongListWithNotExistData() throws Exception {
+        this.mockMvc.perform(get("/api/songs")
+                .param("page", "3")
+                .param("size", "10")
+                .param("searchCriteria", SearchCriteria.TITLE.name())
+                .param("keyword", "하늘")
+                .param("gender", Gender.MALE.name())
+                .param("key", "E")
+                .param("sort", SortStrategy.CHRONOLOGICAL.name())
+                .param("genre", "락")
+        ).andExpect(status().is4xxClientError()).andReturn();
+    }
+
+    @DisplayName("상세 노래 조회에서 여러 키 변경 필터를 적용해본다.")
+    @Test
+    void getDetailSongWithKeyChange() throws Exception {
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("허각")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        dto.setContents(lyricsDtoList);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        long songId = Long.parseLong(response.getContentAsString());
+
+        MvcResult result = this.mockMvc.perform(get("/api/songs/" + songId)
+                        .param("currentKey", "E")
+                        .param("key-up", "true")
+                        .param("key", "2")
+                        .param("gender", "true")
+                )
+                .andExpect(status().isOk()).andReturn();
+
+        JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
+
+        Assertions.assertEquals("F#", jsonObject.optJSONArray("contents").getJSONObject(0).getJSONArray("chords").get(0));
+    }
+
+    @DisplayName("노래의 가사를 수정하면 성공적으로 수정이 되야한다.")
+    @Test
+    void modifySongForLyrics() throws Exception {
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("허각")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        dto.setContents(lyricsDtoList);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        long songId = Long.parseLong(response.getContentAsString());
+
+        dto.getContents().get(dto.getContents().size() - 1).setLyrics("국결 난 지렸거근두");
+        String modifyJson = objectWriter.writeValueAsString(dto);
+        this.mockMvc.perform(put("/api/songs/" + songId)
+                        .content(modifyJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 노래에 대해 수정을 시도하는 경우 예외가 발생한다.")
+    @Test
+    void modifySongNotExist() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        Long songId = songRepository.save(song).getId();
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("달렸다 하늘을")
+                .artist("각허")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String modifyJson = objectWriter.writeValueAsString(dto);
+        this.mockMvc.perform(put("/api/songs/" + (songId + 1))
+                        .content(modifyJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @DisplayName("존재하는 노래를 삭제하면 성공적으로 삭제가 되야한다.")
+    @Test
+    void deleteSong() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        Long songId = songRepository.save(song).getId();
+        this.mockMvc.perform(delete("/api/songs/" + songId))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 노래에 대해 삭제를 시도하는 경우 예외가 발생한다.")
+    @Test
+    void deleteSongNotExist() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+        );
+        Long songId = songRepository.save(song).getId();
+        this.mockMvc.perform(delete("/api/songs/" + (songId + 1)))
+                .andExpect(status().is4xxClientError());
+    }
+}

--- a/src/test/java/com/windry/chordplayer/util/ChordUtilTest.java
+++ b/src/test/java/com/windry/chordplayer/util/ChordUtilTest.java
@@ -1,6 +1,6 @@
-package com.windry.chordplayer.dto;
+package com.windry.chordplayer.util;
 
-import com.windry.chordplayer.util.ChordUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ChordUtilTest {
 
     @Test
+    @DisplayName("다양한 변형 코드에 대해 변경하고자 하는 정수만큼 변경하면 루트 코드가 그만큼 변경되어야한다.")
     void changeKey() {
         String s1 = ChordUtil.changeKey("Gbm/Bb", 3); // Gb - G - G# - A
         String s2 = ChordUtil.changeKey("F#sus4/A#", 3);


### PR DESCRIPTION
- 노래 API의 paging을 사용하는 api의 offset과 size에 default 값을 부여했다.
- 코드 유틸 클래스 테스트 패키징 변경
- Mock API 테스트
  - MockMvc를 활용하여 API에 대한 요청 & 응답 테스트를 진행했다. 
  - mockMvc 객체를 DI하고, post, get, put, delete 등의 메소드를 통해 실제 요청이 가능하도록 테스트를 진행했다. 
  - ObjectMapper를 통해 DTO 클래스를 Json으로 변환하고 요청 바디에 추가할 수 있도록 하였다.
  - 테스트의 결과를 위해 mockMvc 객체의 andExpect() 메소드로 예측되는 상태 코드를 넣고, 요청의 응답 값을 받아오고 싶다면 andReturn() 메소드를 체이닝 기법을 통해 사용할 수 있었다. 
    - 실제 응답 데이터 자체도 Json 형태였기 때문에 이를 DTO로 바로 직렬화해주는 기능은 없어서 아쉬웠다. (못찾은 것일 수 있지만)
  - Mock 테스트를 하는데, 서로 다른 메소드 간에 데이터 등이 영향이 가는 것을 확인했다. 
    - 기존에는 @BeforeEach 어노테이션을 통해 각 테스트를 실행하기 전에 테스트 케이스 데이터를 저장해놓고, 그것과 비교해서 각 테스트를 진행하려고 했었다. 마찬가지로 @Transactional 어노테이션도 사용해서 테스트를 진행했는데, 서로 독립적이지 않고 영향을 줬어서 의문이 들었다.
    - BeforeEach를 통해 객체를 만들고, 테스트가 끝나면 롤백되도록 하는 의도였다. 하지만 BeforeEach 메소드는 따로 실행된 것으로 판단되서 테스트 메소드로 인해 롤백은 연관이 없다고 생각이 들었다. 그래서 @AfterEach 어노테이션으로 테스트가 끝나면 모든 노래 데이터를 지우도록 하였는데, 이것이 먹히지 않았다. 
    - 그래서 아직은 방법은 찾지 못해서 각 테스트 메소드마다 케이스를 생성하면서 테스트를 진행했다. 

- 노래 목록 API에 대해 Paging을 다시 들여다봐야되나 생각이 들었다.
- 더 좋은 테스트 방법도 찾아봐야겠다..