### PR TITLE
docs: Spring Rest Docs을 도입하여 Rest API 문서 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
+    asciidoctorExtensions
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -26,7 +27,15 @@ repositories {
 }
 
 ext {
-    set('snippetsDir', file("build/generated-snippets"))
+    snippetsDir = file("build/generated-snippets")
+}
+
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'BOOT-INF/classes/static/docs'
+    }
 }
 
 dependencies {
@@ -38,6 +47,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     // QueryDsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
@@ -61,6 +71,28 @@ clean {
     delete file(generated)
 }
 
+asciidoctor {
+    dependsOn test
+    configurations 'asciidoctorExtensions'
+    inputs.dir snippetsDir
+
+    sources {
+        include("**/index.adoc", "**/common/*.adoc")
+    }
+
+    baseDirFollowsSourceFile()
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
@@ -69,4 +101,8 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/src/docs/asciidoc/Genre-API.adoc
+++ b/src/docs/asciidoc/Genre-API.adoc
@@ -1,0 +1,20 @@
+[[Genre-API]]
+== Genre API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left // toc (Table Of Contents)를 문서의 좌측에 두기
+:toclevels: 2
+:sectlinks:
+
+[[Genre-생성]]
+=== Genre 생성
+operation::genres/create[snippets='http-request,request-fields,http-response,response-fields']
+
+[[Genre-삭제]]
+=== Genre 삭제
+operation::genres/delete[snippets='path-parameters,http-request,http-response']
+
+[[Genre-전체-조회]]
+=== Genre 전체 조회
+operation::genres/get-all[snippets='http-response,response-fields']

--- a/src/docs/asciidoc/Song-API.adoc
+++ b/src/docs/asciidoc/Song-API.adoc
@@ -1,0 +1,28 @@
+[[Song-API]]
+== Song API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left // toc (Table Of Contents)를 문서의 좌측에 두기
+:toclevels: 2
+:sectlinks:
+
+[[Song-생성]]
+=== Song 생성
+operation::songs/create[snippets='http-request,request-fields,http-response,response-fields']
+
+[[Song-수정]]
+=== Song 수정
+operation::songs/modify[snippets='path-parameters,http-request,request-fields,http-response']
+
+[[Song-삭제]]
+=== Song 삭제
+operation::songs/delete[snippets='path-parameters,http-request,http-response']
+
+[[Song-전체-조회]]
+=== Song 전체 조회
+operation::songs/get-all[snippets='http-request,query-parameters,http-response']
+
+[[Song-상세-조회]]
+=== Song 상세 조회
+operation::songs/get-detail[snippets='http-request,query-parameters,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,10 @@
+= Chord Player REST Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left // toc (Table Of Contents)를 문서의 좌측에 두기
+:toclevels: 2
+:sectlinks:
+
+include::Song-API.adoc[]
+include::Genre-API.adoc[]

--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -13,7 +13,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,11 +26,13 @@ public class SongAPI {
     private final SongService songService;
 
     @PostMapping("")
-    public ResponseEntity<Long> createSongWithChords(
+    public ResponseEntity<Map<String, Long>> createSongWithChords(
             @RequestBody CreateSongDto createSongDto
     ) {
-        Long song = songService.createNewSong(createSongDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(song);
+        Long songId = songService.createNewSong(createSongDto);
+        Map<String, Long> result = new HashMap<>();
+        result.put("songId", songId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
     @GetMapping("")

--- a/src/test/java/com/windry/chordplayer/api/GenreAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/GenreAPITest.java
@@ -9,6 +9,7 @@ import com.windry.chordplayer.repository.GenreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -16,12 +17,19 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 class GenreAPITest {
 
     @Autowired
@@ -44,7 +52,17 @@ class GenreAPITest {
         this.mockMvc.perform(post("/api/genres")
                         .content(json)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andDo(document("genres/create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("name").description("장르 이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("genreId").description("장르의 고유 ID")
+                        )
+                ));
 
     }
 
@@ -74,8 +92,15 @@ class GenreAPITest {
         Genre genre = Genre.builder().name("발라드").build();
         Long genreId = genreRepository.save(genre).getId();
 
-        this.mockMvc.perform(delete("/api/genres/" + genreId))
-                .andExpect(status().isOk());
+        this.mockMvc.perform(delete("/api/genres/{genreId}", genreId))
+                .andExpect(status().isOk())
+                .andDo(document("genres/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("genreId").description("장르의 고유 ID")
+                        )
+                ));
     }
 
     @DisplayName("존재하지 않는 장르 데이터에 대해 삭제 시도 시, 예외가 발생한다.")
@@ -91,8 +116,23 @@ class GenreAPITest {
     @DisplayName("장르 전체 목록을 조회한다.")
     @Test
     void getGenreList() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+        Genre genre2 = Genre.builder().name("발라드").build();
+        genreRepository.save(genre2);
+        Genre genre3 = Genre.builder().name("재즈").build();
+        genreRepository.save(genre3);
+
         this.mockMvc.perform(get("/api/genres"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andDo(document("genres/get-all",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("[]").description("장르 목록"),
+                                fieldWithPath("[].genreId").description("장르의 고유 ID"),
+                                fieldWithPath("[].genreName").description("장르 이름")
+                        )));
     }
 
 }

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -17,6 +17,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -29,12 +30,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 class SongAPITest {
 
     @Autowired
@@ -175,13 +181,30 @@ class SongAPITest {
         ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
         String json = objectWriter.writeValueAsString(dto);
 
-        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+        this.mockMvc.perform(post("/api/songs")
                         .content(json)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated()).andReturn();
-
-        MockHttpServletResponse response = mvcResult.getResponse();
-        System.out.println("response.getContentAsString() = " + response.getContentAsString());
+                .andExpect(status().isCreated())
+                .andDo(document("songs/create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("title").description("노래의 제목"),
+                                fieldWithPath("artist").description("노래의 가수"),
+                                fieldWithPath("originalKey").description("노래의 원키"),
+                                fieldWithPath("gender").description("노래를 부른 가수의 성별"),
+                                fieldWithPath("note").description("이 노래에 작성할 메모").optional(),
+                                fieldWithPath("bpm").description("노래의 BPM").optional(),
+                                fieldWithPath("modulation").description("노래의 전조").optional(),
+                                fieldWithPath("genres[]").description("노래의 장르 목록"),
+                                fieldWithPath("contents[].lyrics").description("노래의 가사").optional(),
+                                fieldWithPath("contents[].tag").description("현재 마디의 상태").optional(),
+                                fieldWithPath("contents[].chords[]").description("현재 마디의 코드 목록")
+                        ),
+                        responseFields(
+                                fieldWithPath("songId").description("저장한 노래의 고유 ID")
+                        )
+                ));
     }
 
 
@@ -204,18 +227,44 @@ class SongAPITest {
         Long id = songRepository.save(song).getId();
 
         MvcResult mvcResult = this.mockMvc.perform(get("/api/songs")
-                .param("page", id.toString())
-                .param("size", "10")
-                .param("searchCriteria", "TITLE")
-                .param("keyword", "하늘")
-                .param("gender", "MALE")
-                .param("key", "E")
-                .param("genre", "락")
-        ).andExpect(status().isOk()).andReturn();
+                        .param("page", id.toString())
+                        .param("size", "10")
+                        .param("searchCriteria", "TITLE")
+                        .param("keyword", "하늘")
+                        .param("gender", "MALE")
+                        .param("key", "E")
+                        .param("genre", "락")
+                ).andExpect(status().isOk())
+                .andDo(document("songs/get-all",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 시작 위치에 대한 노래 ID"),
+                                parameterWithName("size").description("가져올 목록의 개수"),
+                                parameterWithName("searchCriteria").description("검색 기준(제목, 가수)").optional(),
+                                parameterWithName("keyword").description("검색하고자 하는 키워드").optional(),
+                                parameterWithName("gender").description("검색하고자 하는 성별").optional(),
+                                parameterWithName("key").description("검색하고자 하는 노래의 원키").optional(),
+                                parameterWithName("genre").description("검색하고자 하는 노래의 장르").optional(),
+                                parameterWithName("sort").description("목록의 정렬 기준").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("[]").description("노래 목록"),
+                                fieldWithPath("[].songId").description("노래의 고유 ID"),
+                                fieldWithPath("[].title").description("노래의 제목"),
+                                fieldWithPath("[].artist").description("노래의 가수"),
+                                fieldWithPath("[].originalKey").description("노래의 원키"),
+                                fieldWithPath("[].bpm").description("노래의 BPM"),
+                                fieldWithPath("[].modulation").description("노래의 전조"),
+                                fieldWithPath("[].note").description("노래의 노트"),
+                                fieldWithPath("[].gender").description("노래의 성별"),
+                                fieldWithPath("[].genres[]").description("노래의 장르")
+                        )
+                ))
+                .andReturn();
 
         MockHttpServletResponse response = mvcResult.getResponse();
         String content = response.getContentAsString();
-        System.out.println("content = " + content);
 
         JSONArray jsonArray = new JSONArray(content);
 
@@ -288,19 +337,48 @@ class SongAPITest {
                 .andExpect(status().isCreated()).andReturn();
 
         MockHttpServletResponse response = mvcResult.getResponse();
-        long songId = Long.parseLong(response.getContentAsString());
+        JSONObject jsonObject = new JSONObject(response.getContentAsString());
 
-        MvcResult result = this.mockMvc.perform(get("/api/songs/" + songId)
+        MvcResult result = this.mockMvc.perform(get("/api/songs/{songId}", jsonObject.optLong("songId"))
                         .param("currentKey", "E")
                         .param("key-up", "true")
                         .param("key", "2")
                         .param("gender", "true")
+                        .param("offset", "0")
+                        .param("size", "10")
                 )
-                .andExpect(status().isOk()).andReturn();
+                .andExpect(status().isOk())
+                .andDo(document("songs/get-detail",
+                        pathParameters(
+                                parameterWithName("songId").description("노래의 고유 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("currentKey").description("현재 마디에서의 노래 키"),
+                                parameterWithName("offset").description("마지막 가사 마디의 위치"),
+                                parameterWithName("size").description("가져올 가사의 마디 개수"),
+                                parameterWithName("capo").description("기타 카포 적용 크기").optional(),
+                                parameterWithName("tuning").description("기타 튜닝의 종류").optional(),
+                                parameterWithName("gender").description("남/여 키 변경 여부").optional(),
+                                parameterWithName("key-up").description("키 올림 여부").optional(),
+                                parameterWithName("key").description("키 변경할 크기").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("title").description("노래의 제목"),
+                                fieldWithPath("artist").description("노래의 가수"),
+                                fieldWithPath("currentKey").description("현재 노래의 키"),
+                                fieldWithPath("gender").description("현재 노래의 성별"),
+                                fieldWithPath("contents[].line").description("현재 노래의 마디"),
+                                fieldWithPath("contents[].lyrics").description("현재 마디의 가사").optional(),
+                                fieldWithPath("contents[].tag").description("현재 마디의 태그(상태)").optional(),
+                                fieldWithPath("contents[].chords[]").description("현재 마디의 코드 목록")
+                        )
 
-        JSONObject jsonObject = new JSONObject(result.getResponse().getContentAsString());
+                ))
+                .andReturn();
 
-        Assertions.assertEquals("F#", jsonObject.optJSONArray("contents").getJSONObject(0).getJSONArray("chords").get(0));
+        JSONObject jsonObject2 = new JSONObject(result.getResponse().getContentAsString());
+
+        Assertions.assertEquals("F#", jsonObject2.optJSONArray("contents").getJSONObject(0).getJSONArray("chords").get(0));
     }
 
     @DisplayName("노래의 가사를 수정하면 성공적으로 수정이 되야한다.")
@@ -351,17 +429,38 @@ class SongAPITest {
         MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
                         .content(json)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated()).andReturn();
+                .andExpect(status().isCreated())
+                .andReturn();
 
         MockHttpServletResponse response = mvcResult.getResponse();
-        long songId = Long.parseLong(response.getContentAsString());
+        JSONObject jsonObject = new JSONObject(response.getContentAsString());
 
         dto.getContents().get(dto.getContents().size() - 1).setLyrics("국결 난 지렸거근두");
         String modifyJson = objectWriter.writeValueAsString(dto);
-        this.mockMvc.perform(put("/api/songs/" + songId)
+        this.mockMvc.perform(put("/api/songs/{songId}", jsonObject.optLong("songId"))
                         .content(modifyJson)
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andDo(document("songs/modify",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("songId").description("노래의 고유 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("노래의 제목"),
+                                fieldWithPath("artist").description("노래의 가수"),
+                                fieldWithPath("originalKey").description("노래의 원키"),
+                                fieldWithPath("gender").description("노래를 부른 가수의 성별"),
+                                fieldWithPath("note").description("이 노래에 작성할 메모").optional(),
+                                fieldWithPath("bpm").description("노래의 BPM").optional(),
+                                fieldWithPath("modulation").description("노래의 전조").optional(),
+                                fieldWithPath("genres[]").description("노래의 장르 목록"),
+                                fieldWithPath("contents[].lyrics").description("노래의 가사").optional(),
+                                fieldWithPath("contents[].tag").description("현재 마디의 상태").optional(),
+                                fieldWithPath("contents[].chords[]").description("현재 마디의 코드 목록")
+                        )
+                ));
     }
 
     @DisplayName("존재하지 않는 노래에 대해 수정을 시도하는 경우 예외가 발생한다.")
@@ -423,8 +522,16 @@ class SongAPITest {
                 "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
         );
         Long songId = songRepository.save(song).getId();
-        this.mockMvc.perform(delete("/api/songs/" + songId))
-                .andExpect(status().isOk());
+        this.mockMvc.perform(delete("/api/songs/{songId}", songId))
+                .andExpect(status().isOk())
+                .andDo(document("songs/delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("songId").description("노래의 고유 ID")
+                        ))
+                )
+        ;
     }
 
     @DisplayName("존재하지 않는 노래에 대해 삭제를 시도하는 경우 예외가 발생한다.")


### PR DESCRIPTION
- `build.gradle` 파일에 rest docs를 사용하기 위한 추가 설정을 추가해줬다.
  - `./gradlew build`를 통해 빌드를 하게 되면 test → asciidoctor → copyDocument → build 순서로 진행된다.
- 노래 생성 API의 응답이 기존에는 단순 ID 값을 반환했는데, Json 형태로 받기 위해 Map 데이터를 응답 타입으로 변경했다.
- Spring Rest Docs
  - 위 기술을 쓰기 위해서는 API 테스트가 먼저 선행되어야한다. 그래서 이전에 해놓은 MockMvc 테스트에 바로 적용을 할 수 있었다.
  - `andDo()` 메소드를 사용하면 된다. 주의할 점은 이 메소드는 반드시 `andExpect()` 메소드 다음에 호출해야한다. (`andReturn()`은 상관이 없는 듯하다. 그래서 이 메소드는 맨 마지막에 놓는 것으로)
  - document 객체로 문서 저장 위치를 지정하는데, 들어가는 문자열 값은 build 폴더 안에 문서 파일이 저장되는 경로이다. 
  - 그리고 요청 또는 응답의 Json 데이터가 구조적으로 예쁘게 보이기 위해 `preprocessRequest(prettyPrint())`, `preprocessResponse(prettyPrint())` 메소드를 추가해줬다.
  - 그리고 이제 API 스펙에 맞도록, PathVariable, Request Body, Query Parameter 들을 지정해줘야한다.
    - PathVariable: `pathParameters(parameterWithName())`
    - RequestBody: `requestFields(fieldWithPath())`
    - QueryParameter: `queryParameters(parameterWithName())`
    - ResponseBody: `responseFields(fieldWithPath())`
  - 추가로 RequestBody나 QueryParameter 등 실제 테스트에 사용되는 값이 그 필드 값에 들어가지 않거나 null 값이 들어가는 경우 에러가 발생한다. 그래서 그러한 optional 필드의 경우에는 `optional()` 메소드를 붙여주면 된다.
  - MockMvc에 사용되는 perform() 메소드의 HTTP Method는 Rest Docs를 적용하기 위해서는 `import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;` 패키지를 사용해야한다. 
  - 응답 자체가 List 타입인 경우, `responseFields()` 안에 정의된 모든 필드 이름 앞에 `[].`를 지정해준다. 이는 배열이라는 의미를 부여해준다. 최상단에는 배열 그 자체만을 정의해줌으로써, ~~ 목록이라는 것을 알 수 있게끔 해준다.
  - 또는 일반 필드 안에 배열이 있는 경우에는 필드 이름을 {필드 이름}[].{nested 필드 이름} 처럼 사용하면 된다. 
    - 여기도 마찬가지로 null 값이 들어가는 경우에는 `optional()` 메소드를 붙여줘야한다.
  - 위처럼 다 작성하고 빌드를 하면 build/generated-snippets 폴더에 API 스펙이 담긴 .adoc 파일들이 담겨있다.
  - 이 스펙들을 실제 문서처럼 사용하기 위해 `src/docs/asciidoc` 경로에 `index.adoc` 파일을 생성해두고, 여기에 진짜 문서 내용을 작성해준다. 
  - 이 문서만의 문법이 있는 것 같다. (형태는 마크다운과 유사)
  - 각 문서 안에 API 스펙의 경우에는 우리가 빌드하면서 자동으로 생성한 snippets 조각들을 불러오면 된다. (operation)

- 다음으로 해야할 것은 테스트 케이스를 바꾸는 것이다. 테스트할 때 작성한 케이스가 rest docs 문서에 그대로 올라가기 때문이다. 그래서 조금 더 다양하게 보여줄 수 있는 케이스로 변경할 것이다. 
- 그 다음은 문법을 조금 더 익혀서 문서 자체를 예쁘게 꾸밀 것이다.
- 그리고 각 요청 또는 응답의 필드 값의 description을 더 구체적으로 작성하는 것이다. (Enum 데이터의 정의나 제약 조건 등을 추가)