### PR TITLE
refactor: 노래 목록 페이징 로직 수정

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -37,7 +37,7 @@ public class SongAPI {
 
     @GetMapping("")
     public ResponseEntity<List<SongListItemDto>> getSongList(
-            @RequestParam(value = "page", defaultValue = "1") Long page,
+            @RequestParam(value = "page", defaultValue = "0") Long page,
             @RequestParam(value = "size", defaultValue = "10") Long size,
             @RequestParam(value = "searchCriteria", required = false) SearchCriteria searchCriteria,
             @RequestParam(value = "keyword", required = false) String keyword,
@@ -59,9 +59,7 @@ public class SongAPI {
                 .searchKey(key)
                 .build();
 
-        List<SongListItemDto> allSongs = songService.getAllSongs(filters, page, size);
-
-        return ResponseEntity.ok().body(allSongs);
+        return ResponseEntity.ok().body(songService.getAllSongs(filters, page, size));
     }
 
     @GetMapping("/{songId}")

--- a/src/main/java/com/windry/chordplayer/domain/Lyrics.java
+++ b/src/main/java/com/windry/chordplayer/domain/Lyrics.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +24,6 @@ public class Lyrics extends BaseEntity {
     private Song song;
 
     @OneToMany(mappedBy = "lyrics", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Chords> chords = new ArrayList<>();
 
     private String lyrics;
@@ -61,25 +58,30 @@ public class Lyrics extends BaseEntity {
         return chords.stream().map(Chords::getChord).toList();
     }
 
-    public void updateLyrics(Tag tag, String lyrics, List<Chords> chords) {
+    public void updateTag(Tag tag) {
         this.tag = tag;
-        this.lyrics = lyrics;
+    }
 
+    public void updateLyrics(String lyrics) {
+        this.lyrics = lyrics;
+    }
+
+    public void updateChords(List<Chords> newChords) {
         // 코드 업데이트
         for (int i = 0; i < this.chords.size(); ++i) {
-            if (i < chords.size()) {
-                Chords chords1 = this.chords.get(i);
-                Chords chords2 = chords.get(i);
-                chords1.updateChord(chords2.getChord());
+            if (i < newChords.size()) {
+                Chords existChord = this.chords.get(i);
+                Chords updatedChord = newChords.get(i);
+                existChord.updateChord(updatedChord.getChord());
             } else {
                 this.chords.remove(i);
                 i--;
             }
         }
 
-        for (int i = this.chords.size(); i < chords.size(); ++i) {
-            Chords chords1 = chords.get(i);
-            this.chords.add(chords1);
+        for (int i = this.chords.size(); i < newChords.size(); ++i) {
+            Chords newChord = newChords.get(i);
+            this.chords.add(newChord);
         }
     }
 }

--- a/src/main/java/com/windry/chordplayer/domain/Song.java
+++ b/src/main/java/com/windry/chordplayer/domain/Song.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,11 +48,9 @@ public class Song extends BaseEntity {
     private String note;
 
     @OneToMany(mappedBy = "song", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<SongGenre> songGenres = new ArrayList<>();
 
     @OneToMany(mappedBy = "song", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<Lyrics> lyricsList = new ArrayList<>();
 
     @Builder
@@ -68,39 +64,47 @@ public class Song extends BaseEntity {
         this.note = note;
     }
 
-    public void changeRequestFields(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation, List<Lyrics> lyrics, List<SongGenre> songGenres) {
+    public void changeRequestFields(String title, String artist, String originalKey, Gender gender, Integer bpm, String modulation, String note) {
         this.title = title;
         this.artist = artist;
         this.originalKey = originalKey;
         this.gender = gender;
         this.bpm = bpm;
         this.modulation = modulation;
+        this.note = note;
+    }
 
-        if (lyrics != null) {
+    public void updateLyrics(List<Lyrics> newLyrics) {
+        if (newLyrics != null) {
             // 가사 업데이트
             for (int i = 0; i < this.lyricsList.size(); ++i) {
-                if (i < lyrics.size()) {
+                if (i < newLyrics.size()) {
                     Lyrics exist = this.lyricsList.get(i);
-                    Lyrics updated = lyrics.get(i);
-                    exist.updateLyrics(updated.getTag(), updated.getLyrics(), updated.getChords());
+                    Lyrics updated = newLyrics.get(i);
+
+                    exist.updateTag(updated.getTag());
+                    exist.updateLyrics(updated.getLyrics());
+                    exist.updateChords(updated.getChords());
                 } else {
                     this.lyricsList.remove(i);
                     i--;
                 }
             }
 
-            for (int i = this.lyricsList.size(); i < lyrics.size(); ++i) {
-                Lyrics lyrics1 = lyrics.get(i);
+            for (int i = this.lyricsList.size(); i < newLyrics.size(); ++i) {
+                Lyrics lyrics1 = newLyrics.get(i);
                 this.lyricsList.add(lyrics1);
             }
         }
+    }
 
-        if (songGenres != null) {
+    public void updateGenres(List<SongGenre> newGenres) {
+        if (newGenres != null) {
             // 장르 업데이트
             for (int i = 0; i < this.songGenres.size(); ++i) {
-                if (i < songGenres.size()) {
+                if (i < newGenres.size()) {
                     SongGenre exist = this.songGenres.get(i);
-                    SongGenre updated = songGenres.get(i);
+                    SongGenre updated = newGenres.get(i);
                     exist.changeSongGenre(updated.getGenre());
                 } else {
                     this.songGenres.remove(i); // orphanRemoval 속성!!
@@ -108,8 +112,8 @@ public class Song extends BaseEntity {
                 }
             }
 
-            for (int i = this.songGenres.size(); i < songGenres.size(); ++i) {
-                SongGenre songGenre = songGenres.get(i);
+            for (int i = this.songGenres.size(); i < newGenres.size(); ++i) {
+                SongGenre songGenre = newGenres.get(i);
                 this.songGenres.add(songGenre);
             }
         }

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -8,7 +8,6 @@ import com.windry.chordplayer.exception.DuplicateTitleAndArtistException;
 import com.windry.chordplayer.exception.ImpossibleConvertGenderException;
 import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.exception.NoSuchDataException;
-import com.windry.chordplayer.repository.ChordsRepository;
 import com.windry.chordplayer.repository.GenreRepository;
 import com.windry.chordplayer.repository.lyrics.LyricsRepository;
 import com.windry.chordplayer.repository.song.SongRepository;
@@ -29,7 +28,6 @@ public class SongService {
 
     private final SongRepository songRepository;
     private final LyricsRepository lyricsRepository;
-    private final ChordsRepository chordsRepository;
     private final GenreRepository genreRepository;
 
     @Transactional
@@ -80,10 +78,11 @@ public class SongService {
     }
 
     public List<SongListItemDto> getAllSongs(FiltersOfSongList filtersOfSongList, Long page, Long size) {
-        Optional<Song> optionalSong = songRepository.findById(page);
-        if (optionalSong.isEmpty())
-            throw new NoSuchDataException();
-        return songRepository.searchAllSong(filtersOfSongList, page, size, optionalSong.get());
+        Song currentSong = null;
+        if (page != null && page != 0) {
+            currentSong = songRepository.findById(page).orElseThrow(NoSuchDataException::new);
+        }
+        return songRepository.searchAllSong(filtersOfSongList, page, size, currentSong);
     }
 
     @Transactional
@@ -205,9 +204,10 @@ public class SongService {
                 createSongDto.getGender(),
                 createSongDto.getBpm(),
                 createSongDto.getModulation(),
-                lyricsList,
-                songGenres
+                createSongDto.getNote()
         );
+        song.updateLyrics(lyricsList);
+        song.updateGenres(songGenres);
     }
 
     @Transactional

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -66,8 +66,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         songRepository.save(song);
 
         List<String> genreList = new ArrayList<>();
@@ -135,8 +138,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "다정히 내 이름을 부르면", "경서예지", "Db", Gender.FEMALE, 72, null, null, genres
+                "다정히 내 이름을 부르면", "경서예지", "Db", Gender.FEMALE, 72, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         songRepository.save(song);
 
         List<String> genreList = new ArrayList<>();
@@ -293,8 +299,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         Long id = songRepository.save(song).getId();
 
         MvcResult mvcResult = this.mockMvc.perform(get("/api/songs")
@@ -626,8 +635,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         Long songId = songRepository.save(song).getId();
 
         List<String> genreList = new ArrayList<>();
@@ -668,8 +680,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         Long songId = songRepository.save(song).getId();
         this.mockMvc.perform(delete("/api/songs/{songId}", songId))
                 .andExpect(status().isOk())
@@ -696,8 +711,11 @@ class SongAPITest {
         List<SongGenre> genres = new ArrayList<>();
         genres.add(songGenre);
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, genres
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
         Long songId = songRepository.save(song).getId();
         this.mockMvc.perform(delete("/api/songs/" + (songId + 1)))
                 .andExpect(status().is4xxClientError());

--- a/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
+++ b/src/test/java/com/windry/chordplayer/service/SongServiceTest.java
@@ -76,8 +76,10 @@ class SongServiceTest {
                 songDto.getGender(),
                 songDto.getBpm(),
                 songDto.getModulation(),
-                null,
-                songGenres);
+                songDto.getNote()
+        );
+        song.updateLyrics(null);
+        song.updateGenres(songGenres);
 
         Song differentArtistSong = new Song();
 
@@ -88,9 +90,10 @@ class SongServiceTest {
                 songDto.getGender(),
                 songDto.getBpm(),
                 songDto.getModulation(),
-                null,
-                songGenres
+                songDto.getNote()
         );
+        differentArtistSong.updateLyrics(null);
+        differentArtistSong.updateGenres(songGenres);
 
         // when
         Song song1 = songRepository.save(song);
@@ -112,8 +115,10 @@ class SongServiceTest {
 
         Song song = new Song();
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, null
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(null);
 
         List<String> genreList = new ArrayList<>();
         genreList.add("락");
@@ -350,8 +355,10 @@ class SongServiceTest {
 
         Song song = new Song();
         song.changeRequestFields(
-                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null, null
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
         );
+        song.updateLyrics(null);
+        song.updateGenres(null);
 
         List<String> genreList = new ArrayList<>();
         genreList.add("락");


### PR DESCRIPTION
- 페이징할 때, 마지막으로 요청한 데이터의 PK 값을 넘겨줬어야했다. 그래서 그 값 이후로 지정한 개수만큼 데이터를 가져오는 것이였다.
- 문제는 최초 요청할 때, 0 또는 1 값으로 주게 되었을 때, 기존 로직으로는 해당 데이터가 있는지 검사한다. 근데 만약에 노래 데이터를 생성, 삭제의 반복으로 가장 끝에 있는 데이터의 PK 값이 1이 아니라 그 이상이 되는 경우가 있을 수도 있다.
- 그래서 최초의 요청일 때는 PK 조건절을 검사하지 않아야한다. 그래야만 끝에서부터 지정한 개수만큼 가져올 수 있기 때문이다. 
- 그것을 이용하기 위해 최초 요청을 0으로 지정함으로써, null 또는 0인 경우에는 최초 요청인 것으로 간주해서 현재 기준 노래 데이터를 가져오지 않고, null 값을 그대로 넘겨줌으로써, 페이징 Predicate 메소드의 리턴 값이 null이 되어 where 절에 포함되지 않게 되서 최초의 요청일 때는 의도한대로 동작할 수 있다.
- 노래와 가사 엔티티의 업데이트 메소드들을 각각 필드마다 분리시켜주었고, 가독성이 최대한 좋도록 네이밍을 수정했다. 
---
- 페이징을 할 때, DTO의 필드만 가져오고 싶었는데, 그래서 `Projection.constructor()`를 활용하려고 했으나, 테이블 3개의 연관관계로 인해 어떻게 해결해 나가야될지 아직은 모르겠어서 우선 넘어갔다.