### PR TITLE
fix: 필터링 값을 가진 API의 요청 파라미터 타입 수정

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -39,22 +39,22 @@ public class SongAPI {
     public ResponseEntity<List<SongListItemDto>> getSongList(
             @RequestParam(value = "page", defaultValue = "0") Long page,
             @RequestParam(value = "size", defaultValue = "10") Long size,
-            @RequestParam(value = "searchCriteria", required = false) SearchCriteria searchCriteria,
+            @RequestParam(value = "searchCriteria", required = false) String searchCriteria,
             @RequestParam(value = "keyword", required = false) String keyword,
-            @RequestParam(value = "gender", required = false) Gender gender,
+            @RequestParam(value = "gender", required = false) String gender,
             @RequestParam(value = "key", required = false) String key,
             @RequestParam(value = "genre", required = false) String genre,
-            @RequestParam(value = "sort", required = false) SortStrategy sortStrategy
+            @RequestParam(value = "sort", required = false) String sortStrategy
     ) {
 
         if (page == null || size == null)
             throw new InvalidInputException();
 
         FiltersOfSongList filters = FiltersOfSongList.builder()
-                .searchCriteria(searchCriteria)
+                .searchCriteria(SearchCriteria.findMatchedEnumFromString(searchCriteria))
                 .searchKeyword(keyword)
-                .gender(gender)
-                .sortStrategy(sortStrategy)
+                .gender(Gender.findMatchedEnumFromString(gender))
+                .sortStrategy(SortStrategy.findMatchedEnumFromString(sortStrategy))
                 .searchGenre(genre)
                 .searchKey(key)
                 .build();
@@ -66,7 +66,7 @@ public class SongAPI {
     public ResponseEntity<DetailSongDto> getFilteredSong(
             @PathVariable("songId") Long songId,
             @RequestParam(value = "capo", required = false) Integer capo,
-            @RequestParam(value = "tuning", required = false) Tuning tuning,
+            @RequestParam(value = "tuning", required = false) String tuning,
             @RequestParam(value = "gender", required = false) Boolean convertGender,
             @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
             @RequestParam(value = "key", required = false) Integer key,
@@ -86,7 +86,7 @@ public class SongAPI {
 
         FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
                 .capo(capo)
-                .tuning(tuning)
+                .tuning(Tuning.findMatchedEnumFromString(tuning))
                 .convertGender(convertGender)
                 .isKeyUp(isKeyUp)
                 .key(key)

--- a/src/main/java/com/windry/chordplayer/spec/Gender.java
+++ b/src/main/java/com/windry/chordplayer/spec/Gender.java
@@ -3,5 +3,13 @@ package com.windry.chordplayer.spec;
 public enum Gender {
     MALE,
     FEMALE,
-    MIXED
+    MIXED;
+
+    public static Gender findMatchedEnumFromString(String s) {
+        for (Gender g : Gender.values()) {
+            if (g.name().equalsIgnoreCase(s))
+                return g;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/windry/chordplayer/spec/SearchCriteria.java
+++ b/src/main/java/com/windry/chordplayer/spec/SearchCriteria.java
@@ -2,6 +2,14 @@ package com.windry.chordplayer.spec;
 
 public enum SearchCriteria {
     TITLE,
-    ARTIST,
-//    BPM
+    ARTIST;
+
+    //    BPM
+    public static SearchCriteria findMatchedEnumFromString(String s) {
+        for (SearchCriteria sc : SearchCriteria.values()) {
+            if (sc.name().equalsIgnoreCase(s))
+                return sc;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/windry/chordplayer/spec/SortStrategy.java
+++ b/src/main/java/com/windry/chordplayer/spec/SortStrategy.java
@@ -3,5 +3,13 @@ package com.windry.chordplayer.spec;
 public enum SortStrategy {
     NAME,
     CHRONOLOGICAL,
-    VIEW
+    VIEW;
+
+    public static SortStrategy findMatchedEnumFromString(String s) {
+        for (SortStrategy ss : SortStrategy.values()) {
+            if (ss.name().equalsIgnoreCase(s))
+                return ss;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/windry/chordplayer/spec/Tuning.java
+++ b/src/main/java/com/windry/chordplayer/spec/Tuning.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Tuning {
     STANDARD("E A D G B E"),
-//    DROPPED_D("D A D G B E"),
+    //    DROPPED_D("D A D G B E"),
 //    OPEN_D("D A D F# A D"),
 //    MODAL_D("D A D G A D"),
 //    OPEN_G("D G D G B D"),
@@ -20,5 +20,13 @@ public enum Tuning {
     WHOLE_STEP("D G C F A D");
 
     private final String sequence;
+
+    public static Tuning findMatchedEnumFromString(String s) {
+        for (Tuning t : Tuning.values()) {
+            if (t.name().equalsIgnoreCase(s))
+                return t;
+        }
+        return null;
+    }
 
 }

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -366,6 +366,40 @@ class SongAPITest {
         ).andExpect(status().is4xxClientError()).andReturn();
     }
 
+    @DisplayName("노래 목록을 조회할 때, 선택 옵션에 대해 모두 null 값을 부여할 시, 필터링 없이 조회가 된다.")
+    @Test
+    void getSongListWithNoneFilter() throws Exception {
+
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        Song song = new Song();
+        SongGenre songGenre = SongGenre.builder()
+                .genre(genre)
+                .song(song)
+                .build();
+        List<SongGenre> genres = new ArrayList<>();
+        genres.add(songGenre);
+        song.changeRequestFields(
+                "하늘을 달리다", "이적", "E", Gender.MALE, 116, null, null
+        );
+        song.updateLyrics(null);
+        song.updateGenres(genres);
+
+        Long id = songRepository.save(song).getId();
+
+        this.mockMvc.perform(get("/api/songs")
+                .param("page", "0")
+                .param("size", "10")
+                .param("searchCriteria", "null")
+                .param("keyword", (String) "null")
+                .param("gender", "null")
+                .param("key", "null")
+                .param("sort", "null")
+                .param("genre", "null")
+        ).andExpect(status().isOk());
+    }
+
     @DisplayName("상세 노래 조회에서 여러 키 변경 필터를 적용해본다.")
     @Test
     void getDetailSongWithKeyChange() throws Exception {


### PR DESCRIPTION
- 기존 코드에서는 컨트롤러의 요청 파라미터에 Enum 타입을 직접적으로 넣어줬었다. 
- 그런데, 실제로 null인 필터 값으로 요청을 시도하려고 하면 Bad Request가 발생했다. (커스텀 에러도 아닌 스프링에서)
- 에러 로그를 확인하니, "null"이라는 값이 Enum 타입에 매칭시킬 수가 없다는 것이였다. (해당 Enum 클래스에 null이라는 것이 정의되어있지 않다는 것이겠다..) 요청 시 들어오는 값은 문자열 상태의 "null"이기 때문이다. 
- 그렇기 때문에, 요청 파라미터 값이 null을 허용하도록 하기 위해서는 Enum 타입이 아니라 String 타입으로 바꿔줬어야했다.
- 그래서 요청 파라미터의 모든 Enum 타입이었던 것을 모두 String 타입으로 바꿔주었고, 각 Enum 클래스에 enum 데이터를 매칭 시켜주는 메소드를 각각 정의해주고, 받아온 문자열 값을 해당 메소드를 통해 Enum 타입으로 변환시켜주었다. 
- 그에 대한 테스트 코드도 작성해서 성공하였다.

- 노래 서비스 계층에서 다음 전조를 찾는 메소드를 Stream API 방식으로 바꿔주었다. 