### PR TITLE
refactor: 노래 목록 조회 API 문자열 null 처리 추가

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -46,10 +46,6 @@ public class SongAPI {
             @RequestParam(value = "genre", required = false) String genre,
             @RequestParam(value = "sort", required = false) String sortStrategy
     ) {
-
-        if (page == null || size == null)
-            throw new InvalidInputException();
-
         FiltersOfSongList filters = FiltersOfSongList.builder()
                 .searchCriteria(SearchCriteria.findMatchedEnumFromString(searchCriteria))
                 .searchKeyword(keyword)
@@ -58,7 +54,6 @@ public class SongAPI {
                 .searchGenre(genre)
                 .searchKey(key)
                 .build();
-
         return ResponseEntity.ok().body(songService.getAllSongs(filters, page, size));
     }
 

--- a/src/main/java/com/windry/chordplayer/repository/song/SongRepositoryCustomImpl.java
+++ b/src/main/java/com/windry/chordplayer/repository/song/SongRepositoryCustomImpl.java
@@ -152,8 +152,11 @@ public class SongRepositoryCustomImpl implements SongRepositoryCustom {
      * @return 정렬 전략에 따른 현재 기준 데이터 다음의 데이터
      */
     private Predicate pagination(Song cursor, SortStrategy sortStrategy) {
-        if (cursor == null || sortStrategy == null)
+        if (cursor == null)
             return null;
+
+        if (sortStrategy == null)
+            return song.id.lt(cursor.getId());
 
         switch (sortStrategy) {
             case NAME -> song.title.loe(cursor.getTitle());

--- a/src/main/java/com/windry/chordplayer/spec/Tag.java
+++ b/src/main/java/com/windry/chordplayer/spec/Tag.java
@@ -2,6 +2,8 @@ package com.windry.chordplayer.spec;
 
 public enum Tag {
     INTRO,
+    VERSE,
+    CHORUS,
     INTERLUDE,
     MODULATION,
     BRIDGE,
@@ -12,6 +14,6 @@ public enum Tag {
             if (tag.name().equalsIgnoreCase(str))
                 return tag;
         }
-        return null;
+        return Tag.VERSE;
     }
 }

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -307,7 +307,7 @@ class SongAPITest {
         Long id = songRepository.save(song).getId();
 
         MvcResult mvcResult = this.mockMvc.perform(get("/api/songs")
-                        .param("page", id.toString())
+                        .param("page", "0")
                         .param("size", "10")
                         .param("searchCriteria", "TITLE")
                         .param("keyword", "하늘")
@@ -388,21 +388,31 @@ class SongAPITest {
 
         Long id = songRepository.save(song).getId();
 
-        this.mockMvc.perform(get("/api/songs")
+        MvcResult mvcResult = this.mockMvc.perform(get("/api/songs")
                 .param("page", "0")
                 .param("size", "10")
                 .param("searchCriteria", "null")
-                .param("keyword", (String) "null")
+                .param("keyword", "null")
                 .param("gender", "null")
                 .param("key", "null")
                 .param("sort", "null")
                 .param("genre", "null")
-        ).andExpect(status().isOk());
+        ).andExpect(status().isOk()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        String content = response.getContentAsString();
+
+        JSONArray jsonArray = new JSONArray(content);
+
+        assertTrue(jsonArray.length() > 0);
     }
 
     @DisplayName("상세 노래 조회에서 여러 키 변경 필터를 적용해본다.")
     @Test
     void getDetailSongWithKeyChange() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
         List<String> genreList = new ArrayList<>();
         genreList.add("락");
 
@@ -499,6 +509,9 @@ class SongAPITest {
     @DisplayName("노래의 가사를 수정하면 성공적으로 수정이 되야한다.")
     @Test
     void modifySongForLyrics() throws Exception {
+        Genre genre = Genre.builder().name("발라드").build();
+        genreRepository.save(genre);
+
         List<String> genreList = new ArrayList<>();
         genreList.add("발라드");
 


### PR DESCRIPTION
- @RequestParam의 타입을 String으로 변경하고나서, 실제 클라이언트에서 Query parameter를 명시하고 요청을 해보니, null 값이 아닌, 문자열 "null"이 들어온 것을 확인이 되었다. 
- 실제 null 값을 받기 위해서는 해당 parameter의 값을 명시하지 않고 요청을 하는 것이다. 하지만 사용하고 있는 클라이언트에서는 형식화된 구조가 없었어서 문자열 그대로의 query parameter를 요청해야했다. 그래서 모든 필터 옵션을 명시해줘야했다. 
- 그래서 어쩔 수 없이, 서버 단에서 문자열 "null"에 대한 처리를 해주기로 했다. 
- 그 처리를 컨트롤러나 서비스 단에서 하기가 조금 애매하다고 생각이 들었다. 해당 URI에 대한 요청뿐만 아니라 다른 요청에서도 문자열 null에 대한 처리가 필요해보였기 때문이다. 
- 그래서 컨트롤러 단에 도달하기 전에 필드 값을 검증하여 문자열 null 값이 존재하면 실제 null로 변환해주는 작업을 하기로 했다. 이를 위해 Interceptor를 사용해보기로 했다. Interceptor 클래스를 정의하고, preHandle() 메소드에 처리하기로 했다.
- 그리고, WebConfig에 addInterceptor에 정의한 Interceptor 클래스를 등록해준다.
- HttpServletRequest 객체를 통해 요청으로 온 값을 받아올 수 있었는데, 여기서 query parameter 값들을 검증하기로 했다. 하지만 찾아보니, RequestBody나 RequestParam으로 들어오는 값을 조작할 수는 없던 것 같았다. 그저, HttpServletRequest 객체의 attribute로써 변환한 값을 저장하고, 컨트롤러에서 HttpServletRequest 객체를 파라미터로 정의해서 해당 attribute 값을 읽어오는 방법 밖에 없었던 것 같았다. 
- 우선 내가 의도하는 바가 아니였기 때문에 Interceptor 방식은 철회했다. 나중에 다른 api에 대해 처리할 때, 도저히 이거는 interceptor 처리를 해야겠다고 생각이 들 때, 다시 시도해보는 걸로 하겠다.
- 노래 Service의 모든 로직에 for문을 Stream API 방식으로 바꾸었다. 그러면서 장르 데이터를 검색하는 로직에 예외 처리로 exception을 걸었는데, 그것 때문에 테스트 코드 일부가 실패했다. 그래서 실패한 테스트 코드에 장르 데이터를 저장하는 로직을 추가해주었다.
- 태그 Enum 클래스에 Verse, Chorus 값을 추가해주었다.
- 노래 목록 조회 API의 필터 값을 모두 null로 주는 api 테스트를 응답 값을 받고, 목록의 개수로 검증하는 방식으로 변경했다.