### PR TITLE
refactor: 상세 노래 조회 API 예외처리 조정 및 문자열 null 처리 추가

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -4,7 +4,6 @@ import com.windry.chordplayer.dto.song.*;
 import com.windry.chordplayer.spec.Gender;
 import com.windry.chordplayer.spec.SearchCriteria;
 import com.windry.chordplayer.spec.SortStrategy;
-import com.windry.chordplayer.exception.InvalidInputException;
 import com.windry.chordplayer.service.SongService;
 import com.windry.chordplayer.spec.Tuning;
 import lombok.RequiredArgsConstructor;
@@ -60,24 +59,15 @@ public class SongAPI {
     @GetMapping("/{songId}")
     public ResponseEntity<DetailSongDto> getFilteredSong(
             @PathVariable("songId") Long songId,
-            @RequestParam(value = "capo", required = false) Integer capo,
-            @RequestParam(value = "tuning", required = false) String tuning,
-            @RequestParam(value = "gender", required = false) Boolean convertGender,
-            @RequestParam(value = "key-up", required = false) Boolean isKeyUp,
-            @RequestParam(value = "key", required = false) Integer key,
-            @RequestParam(value = "currentKey") String currentKey,
-            @RequestParam(value = "offset", defaultValue = "0") Long offset, // line 에 대한 offset
-            @RequestParam(value = "size", defaultValue = "20") Long size
+            @RequestParam(value = "offset", defaultValue = "0") Long offset, // 마디에 대한 offset
+            @RequestParam(value = "size", defaultValue = "20") Long size, // 가져올 마디의 개수
+            @RequestParam(value = "currentKey") String currentKey, // 현재 마디의 키 값
+            @RequestParam(value = "capo", required = false) Integer capo, // 기타 카포 적용할 프렛
+            @RequestParam(value = "tuning", required = false) String tuning, // 기타 튜닝 방식
+            @RequestParam(value = "gender", required = false) Boolean convertGender, // 성별 변경할지 여부
+            @RequestParam(value = "key-up", required = false) Boolean isKeyUp, // 키를 높일지 여부
+            @RequestParam(value = "key", required = false) Integer key // 변경할 키 값
     ) {
-
-        if (songId == null)
-            throw new InvalidInputException();
-
-        if (offset == null || size == null)
-            throw new InvalidInputException();
-
-        if (currentKey == null)
-            throw new InvalidInputException();
 
         FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
                 .capo(capo)
@@ -87,8 +77,7 @@ public class SongAPI {
                 .key(key)
                 .build();
 
-        DetailSongDto detailSong = songService.getDetailSong(songId, offset, size, filters, currentKey);
-        return ResponseEntity.ok().body(detailSong);
+        return ResponseEntity.ok().body(songService.getDetailSong(songId, offset, size, filters, currentKey));
     }
 
     @PutMapping("/{songId}")

--- a/src/main/java/com/windry/chordplayer/api/converter/StringNullConverters.java
+++ b/src/main/java/com/windry/chordplayer/api/converter/StringNullConverters.java
@@ -1,0 +1,55 @@
+package com.windry.chordplayer.api.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+public class StringNullConverters {
+
+    @Component
+    public static class LongAsNullConverter implements Converter<String, Long> {
+
+        @Override
+        public Long convert(String source) {
+            if ("null".equals(source)) {
+                return null;
+            }
+            return Long.parseLong(source);
+        }
+    }
+
+    @Component
+    public static class BooleanAsNullConverter implements Converter<String, Boolean> {
+
+        @Override
+        public Boolean convert(String source) {
+            if ("null".equals(source)) {
+                return null;
+            }
+            return Boolean.parseBoolean(source);
+        }
+    }
+
+    @Component
+    public static class IntegerAsNullConverter implements Converter<String, Integer> {
+
+        @Override
+        public Integer convert(String source) {
+            if ("null".equals(source)) {
+                return null;
+            }
+            return Integer.parseInt(source);
+        }
+    }
+
+    @Component
+    public static class StringAsNullConverter implements Converter<String, String> {
+
+        @Override
+        public String convert(String source) {
+            if ("null".equals(source)) {
+                return null;
+            }
+            return source;
+        }
+    }
+}

--- a/src/main/java/com/windry/chordplayer/config/WebMvcConfig.java
+++ b/src/main/java/com/windry/chordplayer/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.windry.chordplayer.config;
+
+import com.windry.chordplayer.api.converter.StringNullConverters;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        // 커스텀 컨버터 등록
+        registry.addConverter(new StringNullConverters.BooleanAsNullConverter());
+        registry.addConverter(new StringNullConverters.IntegerAsNullConverter());
+        registry.addConverter(new StringNullConverters.LongAsNullConverter());
+        registry.addConverter(new StringNullConverters.StringAsNullConverter());
+    }
+}

--- a/src/main/java/com/windry/chordplayer/repository/lyrics/LyricsRepositoryCustomImpl.java
+++ b/src/main/java/com/windry/chordplayer/repository/lyrics/LyricsRepositoryCustomImpl.java
@@ -44,6 +44,6 @@ public class LyricsRepositoryCustomImpl implements LyricsRepositoryCustom {
         if (offset == null || offset == 0L) {
             return null;
         }
-        return lyrics1.id.gt(offset);
+        return lyrics1.line.gt(offset);
     }
 }

--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -88,18 +88,6 @@ public class SongService {
         if (size == null || size < 1)
             throw new InvalidInputException();
 
-        if (filtersOfSongList.getSearchKeyword() != null && filtersOfSongList.getSearchKeyword().equals("null")) {
-            filtersOfSongList.setSearchKeyword(null);
-        }
-
-        if (filtersOfSongList.getSearchGenre() != null && filtersOfSongList.getSearchGenre().equals("null")) {
-            filtersOfSongList.setSearchGenre(null);
-        }
-
-        if (filtersOfSongList.getSearchKey() != null && filtersOfSongList.getSearchKey().equals("null")) {
-            filtersOfSongList.setSearchKey(null);
-        }
-
         Song currentSong = null;
         if (page != null && page >= 0 && page != 0) {
             currentSong = songRepository.findById(page).orElseThrow(NoSuchDataException::new);
@@ -114,10 +102,16 @@ public class SongService {
         if (optional.isEmpty())
             throw new NoSuchDataException();
 
+        if (size == null || size < 1)
+            throw new InvalidInputException();
+
+        if (curKey == null)
+            throw new InvalidInputException();
+
         Song song = optional.get();
 
-        int cumulateKey = 0;
-        String currentKey;
+        int cumulateKey = 0; // 최종 키 변경 적용에 대한 변경할 누적 키 값
+        String currentKey; // 키 변경 적용에 대한 최종 키
         Gender currentGender = song.getGender();
 
         List<DetailLyricsDto> lyrics = lyricsRepository.getPagingLyricsBySong(offset, size, songId);
@@ -137,7 +131,7 @@ public class SongService {
         }
 
         // 남/여 키 변경 -> ±5
-        if (filtersOfDetailSong.getConvertGender() != null) {
+        if (filtersOfDetailSong.getConvertGender() != null && filtersOfDetailSong.getConvertGender()) {
             if (!optional.get().getGender().equals(Gender.MIXED)) {
                 int amount = 0;
                 if (optional.get().getGender().equals(Gender.MALE)) {


### PR DESCRIPTION
- Query Parameter에 대한 고찰이 점점 강해졌다. 요청할 때, 해당 파라미터를 명시하지 않으면 자동으로 null이 들어가지만, 무슨 값을 넣던 명시하게 되면 그 값이 들어가게 되서, 해당 타입과 일치하지 않으면 컨트롤러 단에서 예외처리를 하지도 못한 채 바로 400 에러가 뜨게 된다. 
- 물론, 실제 API 요청하는 쪽은 대부분 개발자들이 하는거라서 명시해서 null 값을 보내는 일은 많지않을 것이다.
- 하지만 그럼에도, 그러한 값으로 요청을 보냈을 때, 처리하는 방법을 알고자, 처리하고자 한번 시도를 해보았다. 
- 컨트롤러 단에 들어오기 전에 에러가 발생하는 것이 문제였기 때문에, 컨트롤러 단에 들어오기 전에 처리하는 단계에 들어가야겠다고 생각이 들었다. 그래서 처음에 생각한 것이 Interceptor였다. 요청을 가로채서 요청을 검증, 조작 등 처리하고 컨트롤러에 넘길 수가 있어서 먼저 사용해보았다. 그래서 HttpServletRequest로부터 parameter를 가져올 수 있었는데, 실질적으로 Parameter의 값을 바꿀 수 있는 것이 아니라 이 요청 서블릿의 attribute를 임의적으로 추가하고 가져오는 방식이였다. 
- 그래서, 문자열 "null" 값을 null로 변환한 값을 attribute에 추가를 하게되면 실질적으로 컨트롤러의 `@RequestParam`에 들어오는 것이 아니라 HttpServletRequest의 attribute에 들어가있는 것이다. 그렇기에 컨트롤러에 추가적으로 HttpServletRequest를 정의하고, 거기서 값을 꺼내오는 방식을 사용해야한다. 이는 @RequestParam으로 들어오는 값을 조작하는 것이 아니라 내 의도와 달라서 이 방식은 폐기했다.
- 그 다음 방식은 @Valid 어노테이션을 사용하는 것이다. @RequestParam 필드 값을 검증해서 실패하면 에러가 나서 에러 처리를 컨트롤러에서 처리해서 거기서 값 변환을 하고자 했었다. 
  - 커스텀 Valid 어노테이션과 Validate 클래스를 만듦으로써 써봤지만 문제는 요청 자체부터 에러가 나서 사용조차할 수 없던 방법이였다. 그래서 폐기했다.
- 그 다음 방법은 AOP 방법을 사용해봤다. 사용하는 방법을 아예 몰라서 구글링의 도움을 받아보면서 메소드 호출의 전과 후에 대한 동작을 할 수 있는 것이라고 생각하여, 해당 컨트롤러가 실행되기 전에 AOP 메소드를 실행하여 값을 바꿔보려고 했다.
  - 하지만 문제는 AOP 메소드에서 값을 바꿔도, 실질적으로 @RequestParam의 값은 바뀌지 않는다. 그저 해당 메소드에서 일시적으로만 바뀔 뿐이였다.
  - 그래서 위 방식과 똑같은 문제로 요청 자체부터 이미 타입 변환에 실패해서 문제가 발생하는 것이였다.
- 계속 실패를 해서 차라리 요청 앞단의 타입 매칭을 하는 부분을 파고들어서 그쪽을 건들어야겠다는 생각을 했다.
- 그래서 요청 받는 과정을 살펴보니
  1. DispatcherServlet이 요청을 받음
  2. HandlerMapping을 사용하여 요청에 해당하는 컨트롤러 및 핸들러 메소드를 찾음.
  3. 찾은 핸들러 메소드를 실행하기 전, DispatcherServlet은 HandlerAdapter를 사용하여 메소드의 매개변수를 해결함
  4. HandlerAdapter는 HandlerMethodArgumentResolver를 사용하여 요청의 매개변수를 해결함. 이 단계에서 요청 파라미터를 해당 매개변수의 맞게 변환
- 이것을 보고 자세히 알아보니, HandlerAdapter는 컨트롤러와 핸들러 메소드의 매개변수 정보를 분석하고, 요청 파라미터와 매개변수 간의 변환을 수행하는데, 이때 Converter와 Formatter가 담당한다고 한다.
- 그 중 Converter는 요청 파라미터를 매개변수의 타입으로 변환하는 역할을 수행한다고 한다. 
- 그렇기에! 이 사이 과정을 커스터마이징해서 타입을 변환하는 곳에 내 로직을 추가하면 타입이 잘 변환되어 @RequestParam으로 값이 받아와질 것이라고 생각했다.
- 그래서 Convert<S, T> 인터페이스를 상속하여 타입 별로, 문자열 "null"을 null로 변환해주는 클래스를 작성하고, @Component로 빈 등록을 해주었다. 또한 WebConfig에 addFormatters 오버라이딩 메소드에 각 컨버터들을 등록해주었다.
  - 확실히 이렇게 하고, 실제 테스트를 해보니, 명시적으로 query parameter 값에 null이라는 것을 넣어도 400 에러없이 요청에 성공하는 것을 확인했다.
- 이제 MockMvc 테스트에도 사용하려고 하니, 여기서는 에러가 발생했다. 커스텀 컨버터는 MockMvc 테스트할 때는 적용되지 않는 것이였다. 그래서 직접 커스터마이징한 컨버터를 MockMvc 객체의 설정 값으로 추가를 해줬어야 했다.
- ConversionService에 DI된 각 컨버터들을 추가하고 MockMvcBuilder로 설정 값을 추가해줬다. 
  - 원래 컨버터 객체를 new로 직접 넣어줬었는데, 안되길래 @Autowired로 각 컨버터 빈들을 불러와서 사용하니 정상적으로 작동했다.
- 그래서 위 설정 과정을 @BeforeEach 메소드에 추가해주고 테스트를 실행하였더니 정상적으로 성공하였다.

정말 힘겨운 삽질이였다. 
---
+ 추가로 MockMvc에 대해 설정을 직접하다보니, 어노테이션으로 auto configuration 해주는 것이 무시가 되는 것 같았다.
그래서 All Test를 하게 되면 400 에러가 나도 테스트에 실패하게 되고, rest docs 설정도 안되어있다고 한다.
- 그래서 setup 메소드에 controller advice와 rest docs configuration을 추가해주었다. 