### PR TITLE
feat: 유효 키 검증 기능 추가

### DIFF
--- a/src/main/java/com/windry/chordplayer/api/SongAPI.java
+++ b/src/main/java/com/windry/chordplayer/api/SongAPI.java
@@ -38,12 +38,12 @@ public class SongAPI {
     public ResponseEntity<List<SongListItemDto>> getSongList(
             @RequestParam(value = "page", defaultValue = "0") Long page,
             @RequestParam(value = "size", defaultValue = "10") Long size,
-            @RequestParam(value = "searchCriteria", required = false) String searchCriteria,
-            @RequestParam(value = "keyword", required = false) String keyword,
-            @RequestParam(value = "gender", required = false) String gender,
-            @RequestParam(value = "key", required = false) String key,
-            @RequestParam(value = "genre", required = false) String genre,
-            @RequestParam(value = "sort", required = false) String sortStrategy
+            @RequestParam(value = "searchCriteria", required = false) String searchCriteria, // 검색 기준
+            @RequestParam(value = "keyword", required = false) String keyword, // 검색어
+            @RequestParam(value = "gender", required = false) String gender, // 필터링할 성별
+            @RequestParam(value = "key", required = false) String key, // 필터링할 키
+            @RequestParam(value = "genre", required = false) String genre, // 필터링할 장르
+            @RequestParam(value = "sort", required = false) String sortStrategy // 정렬 기준
     ) {
         FiltersOfSongList filters = FiltersOfSongList.builder()
                 .searchCriteria(SearchCriteria.findMatchedEnumFromString(searchCriteria))
@@ -68,7 +68,6 @@ public class SongAPI {
             @RequestParam(value = "key-up", required = false) Boolean isKeyUp, // 키를 높일지 여부
             @RequestParam(value = "key", required = false) Integer key // 변경할 키 값
     ) {
-
         FiltersOfDetailSong filters = FiltersOfDetailSong.builder()
                 .capo(capo)
                 .tuning(Tuning.findMatchedEnumFromString(tuning))
@@ -76,7 +75,6 @@ public class SongAPI {
                 .isKeyUp(isKeyUp)
                 .key(key)
                 .build();
-
         return ResponseEntity.ok().body(songService.getDetailSong(songId, offset, size, filters, currentKey));
     }
 

--- a/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
+++ b/src/main/java/com/windry/chordplayer/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     INVALID_CHORD_MATCH("4003", "존재하지 않는 코드 형태입니다."),
     DUPLICATE_GENRE_NAME("4004", "이미 존재하는 장르 이름입니다."),
     NO_SUCH_ELEMENT("4005", "존재하지 않는 데이터입니다."),
-    IMPOSSIBLE_MIXED_GENDER_CONVERT("4006", "혼성 키는 키 변경이 불가능합니다.");
+    IMPOSSIBLE_MIXED_GENDER_CONVERT("4006", "혼성 키는 키 변경이 불가능합니다."),
+    INVALID_KEY("4007", "올바르지 않은 키입니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/windry/chordplayer/exception/InvalidKeyException.java
+++ b/src/main/java/com/windry/chordplayer/exception/InvalidKeyException.java
@@ -1,0 +1,9 @@
+package com.windry.chordplayer.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidKeyException extends CustomRuntimeException {
+    public InvalidKeyException() {
+        super(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_KEY);
+    }
+}

--- a/src/test/java/com/windry/chordplayer/api/SongAPITest.java
+++ b/src/test/java/com/windry/chordplayer/api/SongAPITest.java
@@ -3,7 +3,6 @@ package com.windry.chordplayer.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.windry.chordplayer.api.converter.StringNullConverters;
 import com.windry.chordplayer.domain.Genre;
 import com.windry.chordplayer.domain.Song;
 import com.windry.chordplayer.domain.SongGenre;
@@ -17,30 +16,21 @@ import com.windry.chordplayer.spec.SortStrategy;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.restdocs.JUnitRestDocumentation;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -51,7 +41,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 @Transactional
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
-@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 class SongAPITest {
 
     @Autowired
@@ -62,38 +51,6 @@ class SongAPITest {
     private SongRepository songRepository;
     @Autowired
     private GenreRepository genreRepository;
-    @Autowired
-    private StringNullConverters.BooleanAsNullConverter booleanAsNullConverter;
-    @Autowired
-    private StringNullConverters.IntegerAsNullConverter integerAsNullConverter;
-    @Autowired
-    private StringNullConverters.LongAsNullConverter longAsNullConverter;
-    @Autowired
-    private StringNullConverters.StringAsNullConverter stringAsNullConverter;
-    @Autowired
-    private SongAPI songAPI;
-    @Autowired
-    private GlobalExceptionHandler globalExceptionHandler;
-
-    @BeforeEach
-    public void setUp(RestDocumentationContextProvider restDocumentation) {
-        FormattingConversionService formattingConversionService = new FormattingConversionService();
-        formattingConversionService.addConverter(booleanAsNullConverter);
-        formattingConversionService.addConverter(integerAsNullConverter);
-        formattingConversionService.addConverter(longAsNullConverter);
-        formattingConversionService.addConverter(stringAsNullConverter);
-
-        // Conversion 서비스에 커스텀 컨버터를 등록한 뒤, MockMvc 설정에 추가
-        // 추가를 안해주면 MockMvc에는 자동으로 커스텀 컨버터가 적용이 안됨..
-        /*
-            이렇게 직접 set up을 해주면 auto configuration이 무시되는 듯하다. 그래서 controller advice, rest docs 등 수동 설정이 필요
-         */
-        this.mockMvc = MockMvcBuilders.standaloneSetup(songAPI)
-                .setControllerAdvice(globalExceptionHandler) // controller advice 추가
-                .apply(documentationConfiguration(restDocumentation)) // rest docs config 추가
-                .setConversionService(formattingConversionService) // 컨버터 추가
-                .build();
-    }
 
     @DisplayName("이미 존재하는 제목과 가수의 노래를 생성할 때, 예외를 발생한다.")
     @Test
@@ -623,10 +580,10 @@ class SongAPITest {
 
         JSONObject firstJson = new JSONObject(result.getResponse().getContentAsString());
         JSONArray firstArray = firstJson.optJSONArray("contents");
+
         Assertions.assertEquals(3, firstArray.length());
         // 가져온 리스트 중 마지막 마디의 첫번째 코드 값 비교
         Assertions.assertEquals("B", firstArray.optJSONObject(firstArray.length() - 1).getJSONArray("chords").get(0));
-
 
         /*
             두번째 페이징
@@ -645,8 +602,77 @@ class SongAPITest {
 
         JSONObject secondJson = new JSONObject(result2.getResponse().getContentAsString());
         JSONArray secondArray = secondJson.optJSONArray("contents");
+
         // 가져온 리스트 중 마지막 마디의 두번째 코드 값이 키업이 되었는지 비교
         Assertions.assertEquals("A#add2", secondArray.optJSONObject(secondArray.length() - 1).getJSONArray("chords").get(1));
+    }
+
+    @DisplayName("상세 노래 조회에서 현재 키 값이 유효한 키 값이 아니면 예외를 발생한다.")
+    @Test
+    void getDetailSongAsValidCurrentKey() throws Exception {
+        Genre genre = Genre.builder().name("락").build();
+        genreRepository.save(genre);
+
+        List<String> genreList = new ArrayList<>();
+        genreList.add("락");
+
+        CreateSongDto dto = CreateSongDto.builder()
+                .title("하늘을 달리다")
+                .artist("허각")
+                .originalKey("E")
+                .bpm(116)
+                .gender(Gender.MALE)
+                .modulation(null)
+                .contents(null)
+                .genres(genreList)
+                .build();
+        List<LyricsDto> lyricsDtoList = new ArrayList<>();
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("E", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag("INTRO")
+                .lyrics(null)
+                .chords(LyricsDto.getAllChords("B", "A"))
+                .build());
+        lyricsDtoList.add(LyricsDto.builder()
+                .tag(null)
+                .lyrics("두근거렸지 난 결국")
+                .chords(LyricsDto.getAllChords("E", "Aadd2"))
+                .build());
+        dto.setContents(lyricsDtoList);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String json = objectWriter.writeValueAsString(dto);
+
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/songs")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andReturn();
+
+        MockHttpServletResponse response = mvcResult.getResponse();
+        JSONObject jsonObject = new JSONObject(response.getContentAsString());
+
+        Long songId = jsonObject.optLong("songId");
+
+        /*
+            첫번째 페이징
+         */
+        this.mockMvc.perform(get("/api/songs/{songId}", songId)
+                        .param("currentKey", "NOOOO!!")
+                        .param("offset", "0")
+                        .param("size", "3")
+                )
+                .andExpect(status().is4xxClientError());
     }
 
     @DisplayName("노래의 가사를 수정하면 성공적으로 수정이 되야한다.")


### PR DESCRIPTION
- 이전에 작업했던 MockMvc에 컨버터를 적용하기 위한 코드를 제거했다. 이 부분이 없이도 정상 테스트가 동작이 되었기 때문
- 일반 코드가 아닌 노래의 키 값을 입력으로 넣었을 때, 이 키 값이 실제 음악에서 사용되는 키 값인지 유효성 검증을 위한 로직을 서비스에 추가하였다.
  - 상세 노래 조회에서 현재 키 값을 query parameter로 필수로 전달해야하는데, 이 때 이 값이 유효한 키 값인지 검증한다. (만약 가능하다면 현재 노래에서의 유효한지까지 키 변경까지 고려해서 한번 추가해볼 여지가 있다.)
  - 노래 생성에서 입력으로 가져온 originalKey 값이 유효한지 검증한다.
  - 노래 수정에서 입력으로 가져온 originalKey 값이 유효한지 검증한다.
- 추가로 노래 수정에서 제목 & 가수에 대한 중복 검증 단계를 추가하였는데, 단순히 추가하니 테스트 코드에서 실패가 발생했다.
  - 그래서 이를 위해 입력으로 받아온 값과 실제 저장된 제목과 가수를 비교해서 동일하면 검증을 하지않고, 다를 경우 검증하도록 하였다.