### PR TITLE
feat: 노래 데이터의 컨텐츠 코드 데이터의 유효성 검증 추가

### DIFF
--- a/src/main/java/com/windry/chordplayer/service/SongService.java
+++ b/src/main/java/com/windry/chordplayer/service/SongService.java
@@ -75,10 +75,14 @@ public class SongService {
                             .lyrics(contents.get(index).getLyrics())
                             .build();
                     // 코드 객체 생성 후, 가사 엔티티에 추가
-                    contents.get(index).getChords().forEach(chord ->
-                            lyrics.addChords(Chords.builder()
-                                    .chord(chord)
-                                    .build())
+                    contents.get(index).getChords().forEach(chord -> {
+                                // 원본 코드를 추출할 수 있는 정상적인 코드인 경우 추가 (그렇지 않으면 exception 발생)
+                                if (!ChordUtil.extractBaseChord(chord).isEmpty()) {
+                                    lyrics.addChords(Chords.builder()
+                                            .chord(chord)
+                                            .build());
+                                }
+                            }
                     );
                     // 노래 엔티티에 최종 가사 엔티티 저장
                     song.addLyrics(lyrics);
@@ -206,7 +210,6 @@ public class SongService {
         if (isInvalidKey(createSongDto.getOriginalKey()))
             throw new InvalidKeyException();
 
-
         List<SongGenre> songGenres = new ArrayList<>();
 
         // songGenre 엔티티 추가
@@ -233,7 +236,17 @@ public class SongService {
                             .lyrics(contents.get(index).getLyrics())
                             .tag(Tag.findTagByString(contents.get(index).getTag()))
                             .build();
-                    lyrics.changeAllChords(contents.get(index).getChords());
+
+                    // 코드 객체 생성 후, 가사 엔티티에 추가
+                    contents.get(index).getChords().forEach(chord -> {
+                                // 원본 코드를 추출할 수 있는 정상적인 코드인 경우 추가 (그렇지 않으면 exception 발생)
+                                if (!ChordUtil.extractBaseChord(chord).isEmpty()) {
+                                    lyrics.addChords(Chords.builder()
+                                            .chord(chord)
+                                            .build());
+                                }
+                            }
+                    );
                     lyricsList.add(lyrics);
                 });
 


### PR DESCRIPTION
- 기존 코드 유틸 클래스에 있던 루트 코드 추출 메소드를 재활용하였다. 
  - 기본적인 코드 형태가 맞냐에 대한 검증을 하려고 했지만, 더 욕심내서 더 정확하게 정규식을 매칭하려고 했었는데, #이나 b이 안붙으면서 변형 코드인 경우에 까지인 경우를 체크하기에는 너무 복잡하면서 애매했다. 
  - Bsus4와 Baaaaa와 같은 경우, 기존 정규식으로는 모두 통과가 된다. 변형 코드의 종류까지 건드리지 않는 한 체크하는 것은 어렵다고 판단이 되서 루트 코드만 정상인지만 판단하도록하였다. 